### PR TITLE
Table5 1

### DIFF
--- a/white-paper/metadata-schema-recommendations.rst
+++ b/white-paper/metadata-schema-recommendations.rst
@@ -149,7 +149,7 @@ in :numref:`tab-schema-handle-record`.
     | | (Dates)                          |                                                                                                              |
     |                                    |     [{                                                                                                       |
     |                                    |       "Date":{                                                                                               |
-    |                                    |         "dateValue":"1999-11-01",                                                                            |
+    |                                    |         "date":"1999-11-01",                                                                                 |
     |                                    |         "dateType":"Commissioned"                                                                            |
     |                                    |       }                                                                                                      |
     |                                    |     }]                                                                                                       |

--- a/white-paper/metadata-schema-recommendations.rst
+++ b/white-paper/metadata-schema-recommendations.rst
@@ -47,120 +47,133 @@ in :numref:`tab-schema-handle-record`.
 	   can be viewed at
 	   http://hdl.handle.net/21.T11998/0000-001A-3905-F?noredirect
 
-    +------------------------------------+---------------------------------------------------------------------------------------------+
-    | Type                               | Data                                                                                        |
-    +====================================+=============================================================================================+
-    | URL                                | .. code-block:: JSON                                                                        |
-    |                                    |                                                                                             |
-    |                                    |     https://linkedsystems.uk/system/instance/TOOL0022_2490/current/                         |
-    +------------------------------------+---------------------------------------------------------------------------------------------+
-    | | 21.T11148/8eb858ee0b12e8e463a5   | .. code-block:: JSON                                                                        |
-    | | (Identifier)                     |                                                                                             |
-    |                                    |     {                                                                                       |
-    |                                    |       "identifierValue":"http://hdl.handle.net/21.T11998/0000-001A-3905-F",                 |
-    |                                    |       "identiferType":"MeasuringInstrument"                                                 |
-    |                                    |     }                                                                                       |
-    +------------------------------------+---------------------------------------------------------------------------------------------+
-    | | 21.T11148/9a15a4735d4bda329d80   | .. code-block:: JSON                                                                        |
-    | | (LandingPage)                    |                                                                                             |
-    |                                    |     https://linkedsystems.uk/system/instance/TOOL0022_2490/current/                         |
-    +------------------------------------+---------------------------------------------------------------------------------------------+
-    | | 21.T11148/709a23220f2c3d64d1e1   | .. code-block:: JSON                                                                        |
-    | | (Name)                           |                                                                                             |
-    |                                    |     Sea-Bird SBE 37-IM MicroCAT C-T Sensor                                                  |
-    +------------------------------------+---------------------------------------------------------------------------------------------+
-    | | 21.T11148/4eaec4bc0f1df68ab2a7   | .. code-block:: JSON                                                                        |
-    | | (Owners)                         |                                                                                             |
-    |                                    |     [{                                                                                      |
-    |                                    |       "Owner": {                                                                            |
-    |                                    |         "ownerName":"National Oceanography Centre",                                         |
-    |                                    |         "ownerContact":"louise.darroch@bodc.ac.uk",                                         |
-    |                                    |         "ownerIdentifier":{                                                                 |
-    |                                    |           "ownerIdentifierValue":                                                           |
-    |                                    |             "http://vocab.nerc.ac.uk/collection/B75/current/ORG00009/",                     |
-    |                                    |           "ownerIdentifierType":"URL"                                                       |
-    |                                    |          }                                                                                  |
-    |                                    |        }                                                                                    |
-    |                                    |     }]                                                                                      |
-    +------------------------------------+---------------------------------------------------------------------------------------------+
-    | | 21.T11148/1f3e82ddf0697a497432   | .. code-block:: JSON                                                                        |
-    | | (Manufacturers)                  |                                                                                             |
-    |                                    |     [{                                                                                      |
-    |                                    |       "Manufacturer":{                                                                      |
-    |                                    |         "manufacturerName":"Sea-Bird Scientific",                                           |
-    |                                    |         "modelName":"SBE 37-IM",                                                            |
-    |                                    |         "manufacturerIdentifier":{                                                          |
-    |                                    |           "manufacturerIdentifierValue":                                                    |
-    |                                    |             "http://vocab.nerc.ac.uk/collection/L35/current/MAN0013/",                      |
-    |                                    |           "manufacturerIdentifierType":"URL"                                                |
-    |                                    |         }                                                                                   |
-    |                                    |       }                                                                                     |
-    |                                    |     }]                                                                                      |
-    +------------------------------------+---------------------------------------------------------------------------------------------+
-    | | 21.T11148/55f8ebc805e65b5b71dd   | .. code-block:: JSON                                                                        |
-    | | (Description)                    |                                                                                             |
-    |                                    |     A high accuracy conductivity and temperature recorder with an optional                  |
-    |                                    |     pressure sensor designed for deployment on moorings. The IM model has an                |
-    |                                    |     inductive modem for real-time data transmission plus internal flash memory              |
-    |                                    |     data storage.                                                                           |
-    +------------------------------------+---------------------------------------------------------------------------------------------+
-    | | 21.T11148/f76ad9d0324302fc47dd   | .. code-block:: JSON                                                                        |
-    | | (InstrumentType)                 |                                                                                             |
-    |                                    |     http://vocab.nerc.ac.uk/collection/L22/current/TOOL0022/                                |
-    +------------------------------------+---------------------------------------------------------------------------------------------+
-    | | 21.T11148/72928b84e060d491ee41   | .. code-block:: JSON                                                                        |
-    | | (MeasuredVariables)              |                                                                                             |
-    |                                    |     [{                                                                                      |
-    |                                    |       "MeasuredVariable":{                                                                  |
-    |                                    |         "VariableMeasured":                                                                 |
-    |                                    |           "http://vocab.nerc.ac.uk/collection/P01/current/CNDCPR01/"                        |
-    |                                    |       }                                                                                     |
-    |                                    |     },{                                                                                     |
-    |                                    |       "MeasuredVariable":{                                                                  |
-    |                                    |         "VariableMeasured":                                                                 |
-    |                                    |           "http://vocab.nerc.ac.uk/collection/P01/current/PSALPR01/"                        |
-    |                                    |       }                                                                                     |
-    |                                    |     },{                                                                                     |
-    |                                    |       "MeasuredVariable":{                                                                  |
-    |                                    |         "VariableMeasured":                                                                 |
-    |                                    |           "http://vocab.nerc.ac.uk/collection/P01/current/TEMPPR01/"                        |
-    |                                    |       }                                                                                     |
-    |                                    |     },{                                                                                     |
-    |                                    |       "MeasuredVariable":{                                                                  |
-    |                                    |         "VariableMeasured":                                                                 |
-    |                                    |           "http://vocab.nerc.ac.uk/collection/P01/current/PREXMCAT/"                        |
-    |                                    |       }                                                                                     |
-    |                                    |     }]                                                                                      |
-    +------------------------------------+---------------------------------------------------------------------------------------------+
-    | | 21.T11148/22c62082a4d2d9ae2602   | .. code-block:: JSON                                                                        |
-    | | (Dates)                          |                                                                                             |
-    |                                    |     [{                                                                                      |
-    |                                    |       "date":{                                                                              |
-    |                                    |         "date":"1999-11-01",                                                                |
-    |                                    |         "dateType":"Commissioned"                                                           |
-    |                                    |       }                                                                                     |
-    |                                    |     }]                                                                                      |
-    +------------------------------------+---------------------------------------------------------------------------------------------+
-    | | 21.T11148/eb3c713572f681e6c4c3   | .. code-block:: JSON                                                                        |
-    | | (AlternateIdentifiers)           |                                                                                             |
-    |                                    |     [{                                                                                      |
-    |                                    |       "AlternateIdentifier":{                                                               |
-    |                                    |         "AlternateIdentifierValue":"2490",                                                  |
-    |                                    |         "alternateIdentifierType":"serialNumber"                                            |
-    |                                    |       }                                                                                     |
-    |                                    |     }]                                                                                      |
-    +------------------------------------+---------------------------------------------------------------------------------------------+
-    | | 21.T11148/178fb558abc755ca7046   | .. code-block:: JSON                                                                        |
-    | | (RelatedIdentifiers)             |                                                                                             |
-    |                                    |     [{                                                                                      |
-    |                                    |       "RelatedIdentifier":{                                                                 |
-    |                                    |         "RelatedIdentifierValue":                                                           |
-    |                                    |           "https://www.bodc.ac.uk/data/documents/nodb/pdf/37imbrochurejul08.pdf",           |
-    |                                    |         "RelatedIdentifierType": "URL",                                                     |
-    |                                    |         "relationType":"IsDescribedBy "                                                     |
-    |                                    |       }                                                                                     |
-    |                                    |     }]                                                                                      |
-    +------------------------------------+---------------------------------------------------------------------------------------------+
+    +------------------------------------+--------------------------------------------------------------------------------------------------------------+
+    | Type                               | Data                                                                                                         |
+    +====================================+==============================================================================================================+
+    | URL                                | .. code-block:: JSON                                                                                         |
+    |                                    |                                                                                                              |
+    |                                    |     https://linkedsystems.uk/system/instance/TOOL0022_2490/current/                                          |
+    +------------------------------------+--------------------------------------------------------------------------------------------------------------+
+    | | 21.T11148/8eb858ee0b12e8e463a5   | .. code-block:: JSON                                                                                         |
+    | | (Identifier)                     |                                                                                                              |
+    |                                    |     {                                                                                                        |
+    |                                    |       "identifierValue":"http://hdl.handle.net/21.T11998/0000-001A-3905-F",                                  |
+    |                                    |       "identiferType":"Handle"                                                                               |
+    |                                    |     }                                                                                                        |
+    +------------------------------------+--------------------------------------------------------------------------------------------------------------+
+    | | 21.T11148/9a15a4735d4bda329d80   | .. code-block:: JSON                                                                                         |
+    | | (LandingPage)                    |                                                                                                              |
+    |                                    |     https://linkedsystems.uk/system/instance/TOOL0022_2490/current/                                          |
+    +------------------------------------+--------------------------------------------------------------------------------------------------------------+
+    | | 21.T11148/709a23220f2c3d64d1e1   | .. code-block:: JSON                                                                                         |
+    | | (Name)                           |                                                                                                              |
+    |                                    |     Sea-Bird SBE 37-IM MicroCAT C-T Sensor                                                                   |
+    +------------------------------------+--------------------------------------------------------------------------------------------------------------+
+    | | 21.T11148/4eaec4bc0f1df68ab2a7   | .. code-block:: JSON                                                                                         |
+    | | (Owners)                         |                                                                                                              |
+    |                                    |     [{                                                                                                       |
+    |                                    |       "Owner": {                                                                                             |
+    |                                    |         "ownerName":"National Oceanography Centre",                                                          |
+    |                                    |         "ownerContact":"louise.darroch@bodc.ac.uk",                                                          |
+    |                                    |         "ownerIdentifier":{                                                                                  |
+    |                                    |           "ownerIdentifierValue":                                                                            |
+    |                                    |             "http://vocab.nerc.ac.uk/collection/B75/current/ORG00009/",                                      |
+    |                                    |           "ownerIdentifierType":"URL"                                                                        |
+    |                                    |          }                                                                                                   |
+    |                                    |        }                                                                                                     |
+    |                                    |     }]                                                                                                       |
+    +------------------------------------+--------------------------------------------------------------------------------------------------------------+
+    | | 21.T11148/1f3e82ddf0697a497432   | .. code-block:: JSON                                                                                         |
+    | | (Manufacturers)                  |                                                                                                              |
+    |                                    |     [{                                                                                                       |
+    |                                    |       "Manufacturer":{                                                                                       |
+    |                                    |         "manufacturerName":"Sea-Bird Scientific",                                                            |
+    |                                    |         "manufacturerIdentifier":{                                                                           |
+    |                                    |           "manufacturerIdentifierValue":                                                                     |
+    |                                    |             "http://vocab.nerc.ac.uk/collection/L35/current/MAN0013/",                                       |
+    |                                    |           "manufacturerIdentifierType":"URL"                                                                 |
+    |                                    |         }                                                                                                    |
+    |                                    |       }                                                                                                      |
+    |                                    |     }]                                                                                                       |
+    +------------------------------------+--------------------------------------------------------------------------------------------------------------+
+    | | 21.T11148/c1a0ec5ad347427f25d6   | .. code-block:: JSON                                                                                         |
+    | | (Model)                          |                                                                                                              |
+    |                                    |     [{                                                                                                       |
+    |                                    |        "modelName":"Sea-Bird SBE 37 MicroCat IM-CT with optional pressure (submersible) CTD sensor series",  |
+    |                                    |        "modelIdentifier":{                                                                                   |
+    |                                    |          "modelIdentifierValue":                                                                             |
+    |                                    |            "http://vocab.nerc.ac.uk/collection/L22/current/TOOL0022/",                                       |
+    |                                    |          "modelIdentifierType":"URL"                                                                         |
+    |                                    |        }                                                                                                     |
+    |                                    |     }]                                                                                                       |
+    +------------------------------------+--------------------------------------------------------------------------------------------------------------+
+    | | 21.T11148/55f8ebc805e65b5b71dd   | .. code-block:: JSON                                                                                         |
+    | | (Description)                    |                                                                                                              |
+    |                                    |     A high accuracy conductivity and temperature recorder with an optional                                   |
+    |                                    |     pressure sensor designed for deployment on moorings. The IM model has an                                 |
+    |                                    |     inductive modem for real-time data transmission plus internal flash memory                               |
+    |                                    |     data storage.                                                                                            |
+    +------------------------------------+--------------------------------------------------------------------------------------------------------------+
+    | | 21.T11148/f76ad9d0324302fc47dd   | .. code-block:: JSON                                                                                         |
+    | | (InstrumentType)                 |                                                                                                              |
+    |                                    |     [                                                                                                        |
+    |                                    |       "http://vocab.nerc.ac.uk/collection/L05/current/134/",                                                 |
+    |                                    |       "http://vocab.nerc.ac.uk/collection/L05/current/350/"                                                  |
+    |                                    |     ]                                                                                                        |                         
+    +------------------------------------+--------------------------------------------------------------------------------------------------------------+
+    | | 21.T11148/72928b84e060d491ee41   | .. code-block:: JSON                                                                                         |
+    | | (MeasuredVariables)              |                                                                                                              |
+    |                                    |     [{                                                                                                       |
+    |                                    |       "MeasuredVariable":{                                                                                   |
+    |                                    |         "VariableMeasured":                                                                                  |
+    |                                    |           "http://vocab.nerc.ac.uk/collection/P01/current/CNDCPR01/"                                         |
+    |                                    |       }                                                                                                      |
+    |                                    |     },{                                                                                                      |
+    |                                    |       "MeasuredVariable":{                                                                                   |
+    |                                    |         "VariableMeasured":                                                                                  |
+    |                                    |           "http://vocab.nerc.ac.uk/collection/P01/current/PSALPR01/"                                         |
+    |                                    |       }                                                                                                      |
+    |                                    |     },{                                                                                                      |
+    |                                    |       "MeasuredVariable":{                                                                                   |
+    |                                    |         "VariableMeasured":                                                                                  |
+    |                                    |           "http://vocab.nerc.ac.uk/collection/P01/current/TEMPPR01/"                                         |
+    |                                    |       }                                                                                                      |
+    |                                    |     },{                                                                                                      |
+    |                                    |       "MeasuredVariable":{                                                                                   |
+    |                                    |         "VariableMeasured":                                                                                  |
+    |                                    |           "http://vocab.nerc.ac.uk/collection/P01/current/PREXMCAT/"                                         |
+    |                                    |       }                                                                                                      |
+    |                                    |     }]                                                                                                       |
+    +------------------------------------+--------------------------------------------------------------------------------------------------------------+
+    | | 21.T11148/22c62082a4d2d9ae2602   | .. code-block:: JSON                                                                                         |
+    | | (Dates)                          |                                                                                                              |
+    |                                    |     [{                                                                                                       |
+    |                                    |       "Date":{                                                                                               |
+    |                                    |         "dateValue":"1999-11-01",                                                                            |
+    |                                    |         "dateType":"Commissioned"                                                                            |
+    |                                    |       }                                                                                                      |
+    |                                    |     }]                                                                                                       |
+    +------------------------------------+--------------------------------------------------------------------------------------------------------------+
+    | | 21.T11148/eb3c713572f681e6c4c3   | .. code-block:: JSON                                                                                         |
+    | | (AlternateIdentifiers)           |                                                                                                              |
+    |                                    |     [{                                                                                                       |
+    |                                    |       "AlternateIdentifier":{                                                                                |
+    |                                    |         "AlternateIdentifierValue":"2490",                                                                   |
+    |                                    |         "alternateIdentifierType":"serialNumber"                                                             |
+    |                                    |       }                                                                                                      |
+    |                                    |     }]                                                                                                       |
+    +------------------------------------+--------------------------------------------------------------------------------------------------------------+
+    | | 21.T11148/178fb558abc755ca7046   | .. code-block:: JSON                                                                                         |
+    | | (RelatedIdentifiers)             |                                                                                                              |
+    |                                    |     [{                                                                                                       |
+    |                                    |       "RelatedIdentifier":{                                                                                  |
+    |                                    |         "RelatedIdentifierValue":                                                                            |
+    |                                    |           "https://www.bodc.ac.uk/data/documents/nodb/pdf/37imbrochurejul08.pdf",                            |
+    |                                    |         "RelatedIdentifierType": "URL",                                                                      |
+    |                                    |         "relationType":"IsDescribedBy "                                                                      |
+    |                                    |       }                                                                                                      |
+    |                                    |     }]                                                                                                       |
+    +------------------------------------+--------------------------------------------------------------------------------------------------------------+
 
 Using other PIDs
 ----------------


### PR DESCRIPTION
Updated table 5-1 to reflect ePIC schema change to old verbose re: dates.

[{"Date":{"date":"2019-01-02","dateType":"Commissioned"}}]