### PR TITLE
updated schema examples and text to v1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /__pycache__/
 /_build/
 /_meta.py
+.vscode/

--- a/epic-cookbook/handles.rst
+++ b/epic-cookbook/handles.rst
@@ -73,7 +73,7 @@ To manually generate a suffix using PUT method::
 Viewing PID handle records
 --------------------------
 
-If you have specified the URLproperty in the handle record it will
+If you have specified the URL property in the handle record it will
 automatically redirect you to it when you view the handle record:
 
 http://hdl.handle.net/21.T11998/0000-001A-3905-F

--- a/examples/ePIC_json_example.json
+++ b/examples/ePIC_json_example.json
@@ -8,6 +8,10 @@
     "parsed_data": "{\"identifierValue\":\"http://hdl.handle.net/21.T11998/0000-001A-3905-F\",\"identifierType\":\"Handle\"}"
   },
   {
+    "type": "21.T11148/f5e68cc7718a6af2a96c",
+    "parsed_data": "1.0"
+  },
+  {
     "type": "21.T11148/9a15a4735d4bda329d80",
     "parsed_data": "https://linkedsystems.uk/system/instance/TOOL0022_2490/current/"
   },
@@ -33,7 +37,7 @@
   },
   {
     "type": "21.T11148/f76ad9d0324302fc47dd",
-    "parsed_data": "[\"http://vocab.nerc.ac.uk/collection/L05/current/134/\",\"http://vocab.nerc.ac.uk/collection/L05/current/350/\"]"
+    "parsed_data": "[{\"instrumentTypeName\":\"water temperature sensor\",\"instrumentTypeIdentifier\":{\"instrumentTypeIdentifierValue\":\"http://vocab.nerc.ac.uk/collection/L05/current/134/\",\"instrumentTypeIdentifierType\":\"URL\"}},{\"instrumentTypeName\":\"salinity sensor\",\"InstrumentTypeIdentifier\":{\"instrumentTypeIdentifierValue\":\"http://vocab.nerc.ac.uk/collection/L05/current/350/\",\"instrumentTypeIdentifierType\":\"URL\"}}]"
   },
   {
     "type": "21.T11148/72928b84e060d491ee41",

--- a/white-paper/landing-page-encoding.rst
+++ b/white-paper/landing-page-encoding.rst
@@ -18,7 +18,7 @@ JSON-LD
 ~~~~~~~
 
 There is a strong relation between PIDs with values of types that are
-defined in a data type registry (DTR) as for instance in the NERC
+defined in a data type registry (DTR) as for instance in the
 example in :numref:`tab-schema-handle-record` and linked data. First
 of all a PID with a type value is a triple where the PID plays the
 role of the subject, the type definition is the predicate and the
@@ -45,7 +45,7 @@ respective representation in JSON-LD of the schema example shown in
 
 .. _snip-landing-encoding-json-ld:
 .. code-block:: JSON
-    :caption: representation in JSON-LD of the NERC example of
+    :caption: representation in JSON-LD of the example of
 	      :numref:`tab-schema-handle-record`.
 
         {

--- a/white-paper/metadata-schema-recommendations.rst
+++ b/white-paper/metadata-schema-recommendations.rst
@@ -29,7 +29,7 @@ terminologies. While free text is allowed, institutions should consider
 using common terminologies where practical to enhance the (semantic)
 interoperability of PID records, particularly where they form part of
 domain-specific best practice. For example, a comprehensive set of
-terminologies that describe *instrumentType* or the recently added
+terminologies that describe *instrumentType* (via *instrumentTypeIdentifier*) or 
 *Model* (via *modelIdentifier*) are used widely in the Earth science
 marine domain (`http://vocab.nerc.ac.uk/collection/L22/current/ <http://vocab.nerc.ac.uk/collection/L22/current/>`_,
 `http://vocab.nerc.ac.uk/collection/L05/current/ <http://vocab.nerc.ac.uk/collection/L05/current/>`_).
@@ -52,7 +52,7 @@ in :numref:`tab-schema-handle-record`.
     +====================================+==============================================================================================================+
     | URL                                | .. code-block:: JSON                                                                                         |
     |                                    |                                                                                                              |
-    |                                    |     https://linkedsystems.uk/system/instance/TOOL0022_2490/current/                                          |
+    |                                    |     "https://linkedsystems.uk/system/instance/TOOL0022_2490/current/"                                        |
     +------------------------------------+--------------------------------------------------------------------------------------------------------------+
     | | 21.T11148/8eb858ee0b12e8e463a5   | .. code-block:: JSON                                                                                         |
     | | (Identifier)                     |                                                                                                              |
@@ -61,13 +61,17 @@ in :numref:`tab-schema-handle-record`.
     |                                    |       "identifierType":"Handle"                                                                              |
     |                                    |     }                                                                                                        |
     +------------------------------------+--------------------------------------------------------------------------------------------------------------+
+    | | 21.T11148/f5e68cc7718a6af2a96c   | .. code-block:: JSON                                                                                         |
+    | | (SchemaVersion)                  |                                                                                                              |
+    |                                    |     "1.0"                                                                                                    |
+    +------------------------------------+--------------------------------------------------------------------------------------------------------------+
     | | 21.T11148/9a15a4735d4bda329d80   | .. code-block:: JSON                                                                                         |
     | | (LandingPage)                    |                                                                                                              |
-    |                                    |     https://linkedsystems.uk/system/instance/TOOL0022_2490/current/                                          |
+    |                                    |     "https://linkedsystems.uk/system/instance/TOOL0022_2490/current/"                                        |
     +------------------------------------+--------------------------------------------------------------------------------------------------------------+
     | | 21.T11148/709a23220f2c3d64d1e1   | .. code-block:: JSON                                                                                         |
     | | (Name)                           |                                                                                                              |
-    |                                    |     Sea-Bird SBE 37-IM MicroCAT C-T Sensor                                                                   |
+    |                                    |     "Sea-Bird SBE 37-IM MicroCAT C-T Sensor"                                                                 |
     +------------------------------------+--------------------------------------------------------------------------------------------------------------+
     | | 21.T11148/4eaec4bc0f1df68ab2a7   | .. code-block:: JSON                                                                                         |
     | | (Owners)                         |                                                                                                              |
@@ -109,10 +113,28 @@ in :numref:`tab-schema-handle-record`.
     +------------------------------------+--------------------------------------------------------------------------------------------------------------+
     | | 21.T11148/55f8ebc805e65b5b71dd   | .. code-block:: JSON                                                                                         |
     | | (Description)                    |                                                                                                              |
-    |                                    |     A high accuracy conductivity and temperature recorder with an optional                                   |
+    |                                    |     "A high accuracy conductivity and temperature recorder with an optional                                  |
     |                                    |     pressure sensor designed for deployment on moorings. The IM model has an                                 |
     |                                    |     inductive modem for real-time data transmission plus internal flash memory                               |
-    |                                    |     data storage.                                                                                            |
+    |                                    |     data storage."                                                                                           |
+    +------------------------------------+--------------------------------------------------------------------------------------------------------------+
+    | | 21.T11148/f76ad9d0324302fc47dd   | .. code-block:: JSON                                                                                         |
+    | | (InstrumentType)                 |                                                                                                              |
+    |                                    |     [{                                                                                                       |
+    |                                    |        "instrumentTypeName":"water temperature sensor",                                                      |
+    |                                    |        "instrumentTypeIdentifier":{                                                                          |
+    |                                    |          "instrumentTypeIdentifierValue":                                                                    |
+    |                                    |            "http://vocab.nerc.ac.uk/collection/L05/current/134/",                                            |
+    |                                    |          "instrumentTypeIdentifierType":"URL"                                                                |
+    |                                    |        }                                                                                                     |
+    |                                    |     },{                                                                                                      |
+    |                                    |        "instrumentTypeName":"salinity sensor",                                                               |
+    |                                    |        "instrumentTypeIdentifier":{                                                                          |
+    |                                    |          "instrumentTypeIdentifierValue":                                                                    |
+    |                                    |            "http://vocab.nerc.ac.uk/collection/L05/current/350/",                                            |
+    |                                    |          "instrumentTypeIdentifierType":"URL"                                                                |
+    |                                    |        }                                                                                                     |
+    |                                    |     }]                                                                                                       |
     +------------------------------------+--------------------------------------------------------------------------------------------------------------+
     | | 21.T11148/f76ad9d0324302fc47dd   | .. code-block:: JSON                                                                                         |
     | | (InstrumentType)                 |                                                                                                              |

--- a/white-paper/metadata-schema-recommendations.rst
+++ b/white-paper/metadata-schema-recommendations.rst
@@ -134,14 +134,7 @@ in :numref:`tab-schema-handle-record`.
     |                                    |            "http://vocab.nerc.ac.uk/collection/L05/current/350/",                                            |
     |                                    |          "instrumentTypeIdentifierType":"URL"                                                                |
     |                                    |        }                                                                                                     |
-    |                                    |     }]                                                                                                       |
-    +------------------------------------+--------------------------------------------------------------------------------------------------------------+
-    | | 21.T11148/f76ad9d0324302fc47dd   | .. code-block:: JSON                                                                                         |
-    | | (InstrumentType)                 |                                                                                                              |
-    |                                    |     [                                                                                                        |
-    |                                    |       "http://vocab.nerc.ac.uk/collection/L05/current/134/",                                                 |
-    |                                    |       "http://vocab.nerc.ac.uk/collection/L05/current/350/"                                                  |
-    |                                    |     ]                                                                                                        |                         
+    |                                    |     }]                                                                                                       |                    
     +------------------------------------+--------------------------------------------------------------------------------------------------------------+
     | | 21.T11148/72928b84e060d491ee41   | .. code-block:: JSON                                                                                         |
     | | (MeasuredVariables)              |                                                                                                              |

--- a/white-paper/metadata-schema-recommendations.rst
+++ b/white-paper/metadata-schema-recommendations.rst
@@ -33,7 +33,7 @@ terminologies that describe *instrumentType* (via *instrumentTypeIdentifier*) or
 *Model* (via *modelIdentifier*) are used widely in the Earth science
 marine domain (`http://vocab.nerc.ac.uk/collection/L22/current/ <http://vocab.nerc.ac.uk/collection/L22/current/>`_,
 `http://vocab.nerc.ac.uk/collection/L05/current/ <http://vocab.nerc.ac.uk/collection/L05/current/>`_).
-An example of the use of common terminologies in ePID records is shown
+An example of the use of common terminologies in ePIC records is shown
 in :numref:`tab-schema-handle-record`.
 
 .. _tab-schema-handle-record:

--- a/white-paper/metadata-schema.rst
+++ b/white-paper/metadata-schema.rst
@@ -46,7 +46,8 @@ their semantics:
 
   `Owner` is a complex property having at least the subproperty
   `ownerName` and optionally a contact address in `ownerContact` and a
-  persistent identifier of the owner in `ownerIdentifier`.
+  common identifier of the owner in `ownerIdentifier` and its type in
+  `ownerIdentifierType`.
 
 `Manufacturer`
   The organization or individual that built the instrument.  In the
@@ -60,17 +61,17 @@ their semantics:
   metadata.
 
   In the same way as `Owner`, `Manufacturer` is a complex property
-  with subproperties `manufacturerName`, `manufacturerContact`, and
-  `manufacturerIdentifier`.
+  with subproperties `manufacturerName`, `manufacturerIdentifier` and
+  `manufacturerIdentifierType`.
 
 `Model`
   The name of the model or type of the instrument.  In the
   case of an off the shelf product, this may be a brand name
   attributed by the manufacturer.  In the case of an custom built
   instrument, it may not have a model name.  Hence this property is
-  not mandatory, but recommended if the value can be obtained.  `Model` has an
-  optional subproperty `modelIdentifier` to be used if a persistent
-  identifier for the model is known.
+  not mandatory, but recommended if the value can be obtained.  `Model` has
+  optional subproperties `modelIdentifier` and `modelIdentifierType` to be used 
+  if an identifier for the model is known.
 
 `Description`
   A textual description of the device and its capabilities.  This is
@@ -78,20 +79,20 @@ their semantics:
   what this instrument is and what it can do.
 
 `InstrumentType`
-  A classification of the type of the instrument.  At present, there
-  is no global classification scheme that would apply to instruments
-  in all scientific domains.  Some communities have established
-  schemes that are specific to their respective domain.  If such a
-  specific classification is applicable, it should be used for
-  `InstrumentType`, see :ref:`pidinst-metadata-schema-terminologies`.
-  Otherwise, a textual description of the type of the instrument may
-  be used.
+  A classification of the type of the instrument.  Hierarchical 
+  classification enables grouping of instrument records.
+
+  In the same way as `Owner`, `Manufacturer` and `Model`, `InstrumentType` is 
+  a complex property with subproperties `instrumentTypeName`, 
+  `instrumentTypeIdentifier` and `instrumentTypeIdentifierType`.
 
 `MeasuredVariable`
   The variables or physical properties that the instrument measures or
-  observes.  Again, there is no overarching classification scheme
-  established in all scientific domains at present, but specific
-  classification should be used if applicable.
+  observes. Some communities have established vocabularies or schemes 
+  to identify measured variables that are specific to their respective domain 
+  (see :ref:`pidinst-metadata-schema-terminologies`).  If such a 
+  standard is applicable, it should be used for for `MeasuredVariable`.
+  Otherwise, a textual description may be used.
 
 `Date`
   Relevant events pertaining to this instrument instance, such as when
@@ -120,7 +121,7 @@ their semantics:
   they allow the automatic aggregation of a rich set of information
   about the instrument.  Each `RelatedIdentifier` needs to have
   subproperties `relatedIdentifierType` and `relationType` to specify
-  the type of the related PID and the type of the relation
+  the type of the related identifier and the type of the relation
   respectively.
 
 `AlternateIdentifier`

--- a/white-paper/metadata-schema.rst
+++ b/white-paper/metadata-schema.rst
@@ -3,11 +3,14 @@
 PIDINST metadata schema
 =======================
 
-The metadata that is to be registered with an instrument PID need to
+The metadata that is to be registered with an instrument PID needs to
 contain enough information to unambiguously identify the
-instrument across networks and infrastructures.  It furthermore allows
-to link resources related to the instrument and thus provides a mean
-to aggregate information about the instrument.
+instrument across networks and infrastructures. It should also allow
+linking related resources to the instrument, thus providing a means
+to aggregate information about the instrument. The PIDINST working group defined 
+a schema of metadata that can be registered alongside instrument PIDs at 
+PID providers to help meet these criteria. Version 1.0 has been endorsed
+as an RDA recommendation\ [#pidinst2022v1_0]_.
 
 Currently, two variants of the metadata schema exist.  The original
 `PIDINST schema`_, based on the evaluation of use cases collected by
@@ -22,6 +25,9 @@ their semantics:
   The PID of the instrument.  The subproperty
   `identifierType` contains the type of the PID, e.g. `Handle` or
   `DOI` in the case of an ePIC Handle or a DataCite DOI respectively.
+
+`SchemaVersion`
+  The version number of the PIDINST schema used to create a record.
 
 `LandingPage`
   The URL of the landing page that the PID resolves to.
@@ -136,3 +142,10 @@ their semantics:
 
 .. _PIDINST DataCite schema:
    https://github.com/rdawg-pidinst/schema/blob/master/schema-datacite.rst
+
+.. [#pidinst2022v1_0]
+   Krahl, R., Darroch, L., Huber, R., Devaraju, A., Klump, J., Habermann, T., 
+   Stocker, M., & The Research Data Alliance Persistent Identification of 
+   Instruments Working Group members (2022). Metadata Schema for the 
+   Persistent Identification of Instruments (1.0). Research Data Alliance. 
+   DOI: https://doi.org/10.15497/RDA00070

--- a/white-paper/metadata-schema.rst
+++ b/white-paper/metadata-schema.rst
@@ -67,7 +67,7 @@ their semantics:
 `Model`
   The name of the model or type of the instrument.  In the
   case of an off the shelf product, this may be a brand name
-  attributed by the manufacturer.  In the case of an custom built
+  attributed by the manufacturer.  In the case of a custom built
   instrument, it may not have a model name.  Hence this property is
   not mandatory, but recommended if the value can be obtained.  `Model` has
   optional subproperties `modelIdentifier` and `modelIdentifierType` to be used 
@@ -88,7 +88,7 @@ their semantics:
 
 `MeasuredVariable`
   The variables or physical properties that the instrument measures or
-  observes. Some communities have established vocabularies or schemes 
+  observes. Some communities have established terminologies 
   to identify measured variables that are specific to their respective domain 
   (see :ref:`pidinst-metadata-schema-terminologies`).  If such a 
   standard is applicable, it should be used for for `MeasuredVariable`.


### PR DESCRIPTION
Fixed examples and text to reflect Schema Version 1.0 (to include Schema Version and instrumentType identifiers). Specifically:

https://github.com/rdawg-pidinst/white-paper/blob/hotfix/update-epic-pid-example/white-paper/metadata-schema-recommendations.rst

https://github.com/rdawg-pidinst/white-paper/blob/hotfix/update-epic-pid-example/white-paper/metadata-schema.rst