### PR TITLE
Add competing interests statement

### DIFF
--- a/white-paper/authors.rst
+++ b/white-paper/authors.rst
@@ -12,23 +12,23 @@ MARUM - Center for Marine Environmental Sciences, University of Bremen, Leobener
 GWDG, Gesellschaft für wissenschaftliche Datenverarbeitung Göttingen, Am
 Fassberg 11, 37077 Göttingen, Germany
 
-*Anita Bandrowski* (abandrowski@ucsd.edu, https://orcid.org/0000-0002-5497-0243),
-Department of Neuoscience, University of California at San Diego,
-9500 Gilman Drive La Jolla, CA 92093-0662
-
-*Markus Stocker* (markus.stocker@tib.eu, https://orcid.org/0000-0001-5492-3212),
-TIB Leibniz Information Centre for Science and Technology, Welfengarten
-1 B, 30167 Hannover, Germany and PANGAEA, Center for Marine
-Environmental Sciences (MARUM), University of Bremen, Leobener Str. 8,
-28359 Bremen, Germany
-
 *Rolf Krahl* (rolf.krahl@helmholtz-berlin.de, https://orcid.org/0000-0002-1266-3819),
 Helmholtz-Zentrum Berlin für Materialien und Energie GmbH,
 Albert-Einstein-Str. 15, 12489 Berlin, Germany
 
+sven.bingert@gwdg.de
+
+philipp.wieder@gwdg.de
+
+*Anita Bandrowski* (abandrowski@ucsd.edu, https://orcid.org/0000-0002-5497-0243),
+Department of Neuroscience, University of California at San Diego,
+9500 Gilman Drive La Jolla, CA 92093-0662
+
 *Ted Habermann* (ted@tedhabermann.com, http://orcid.org/0000-0003-3585-6733),
 Metadata Game Changers, 3980 Broadway, Suite 103-185, Boulder,
 Colorado, USA 80304
+
+mark.vandesanden@surf.nl
 
 *Claudio D'Onofrio* (claudio.donofrio@nateko.lu.se, https://orcid.org/0000-0002-1982-3889),
 ICOS Carbon Portal, Lund University, Physical Geography & Ecosystem
@@ -53,6 +53,14 @@ Germany
 
 *Tina Dohna* (tdohna@marum.de, https://orcid.org/0000-0002-5948-0980),
 MARUM - Center for Marine Environmental Sciences, University of Bremen, Leobener Str. 8, 28199 Bremen, Germany
+
+*Jens Klump* (jens.klump@csiro.au, https://orcid.org/0000-0001-5911-6022),
+CSIRO Mineral Resources, 26 Dick Perry Avenue, Kensington WA 6151, Australia
+
+*Markus Stocker* (markus.stocker@tib.eu, https://orcid.org/0000-0001-5492-3212),
+TIB Leibniz Information Centre for Science and Technology,
+Welfengarten 1 B, 30167 Hannover, Germany and Leibniz University
+Hannover, Welfengarten 1, 30167 Hannover, Germany
 
 *The Research Data Alliance Persistent Identification of Instruments
 Working Group members* (https://www.rd-alliance.org/node/57186/members)

--- a/white-paper/authors.rst
+++ b/white-paper/authors.rst
@@ -16,9 +16,13 @@ Fassberg 11, 37077 Göttingen, Germany
 Helmholtz-Zentrum Berlin für Materialien und Energie GmbH,
 Albert-Einstein-Str. 15, 12489 Berlin, Germany
 
-sven.bingert@gwdg.de
+*Sven Bingert* (sven.bingert@gwdg.de, https://orcid.org/0000-0001-9547-1582),
+GWDG, Gesellschaft für wissenschaftliche Datenverarbeitung Göttingen,
+Burckhardtweg 4, 37077 Göttingen, Germany
 
-philipp.wieder@gwdg.de
+*Philipp Wieder* (philipp.wieder@gwdg.de, https://orcid.org/0000-0002-6992-1866),
+GWDG, Gesellschaft für wissenschaftliche Datenverarbeitung Göttingen,
+Burckhardtweg 4, 37077 Göttingen, Germany
 
 *Anita Bandrowski* (abandrowski@ucsd.edu, https://orcid.org/0000-0002-5497-0243),
 Department of Neuroscience, University of California at San Diego,

--- a/white-paper/authors.rst
+++ b/white-paper/authors.rst
@@ -13,7 +13,7 @@ GWDG, Gesellschaft für wissenschaftliche Datenverarbeitung Göttingen, Am
 Fassberg 11, 37077 Göttingen, Germany
 
 *Rolf Krahl* (rolf.krahl@helmholtz-berlin.de, https://orcid.org/0000-0002-1266-3819),
-Helmholtz-Zentrum Berlin für Materialien und Energie GmbH,
+Helmholtz-Zentrum Berlin für Materialien und Energie,
 Albert-Einstein-Str. 15, 12489 Berlin, Germany
 
 *Sven Bingert* (sven.bingert@gwdg.de, https://orcid.org/0000-0001-9547-1582),

--- a/white-paper/authors.rst
+++ b/white-paper/authors.rst
@@ -28,7 +28,8 @@ Burckhardtweg 4, 37077 Göttingen, Germany
 
 *Anita Bandrowski* (abandrowski@ucsd.edu, https://orcid.org/0000-0002-5497-0243),
 Department of Neuroscience, University of California at San Diego,
-9500 Gilman Drive La Jolla, CA 92093-0662
+9500 Gilman Drive La Jolla, CA 92093-0662 and SciCrunch Inc, 9500
+Gilman Drive La Jolla, CA 92093-0662
 
 *Ted Habermann* (ted@tedhabermann.com, http://orcid.org/0000-0003-3585-6733),
 Metadata Game Changers, 3980 Broadway, Suite 103-185, Boulder,

--- a/white-paper/authors.rst
+++ b/white-paper/authors.rst
@@ -35,7 +35,8 @@ Gilman Drive La Jolla, CA 92093-0662
 Metadata Game Changers, 3980 Broadway, Suite 103-185, Boulder,
 Colorado, USA 80304
 
-mark.vandesanden@surf.nl
+*Mark van de Sanden* (mark.vandesanden@surf.nl, https://orcid.org/0000-0002-2718-8918),
+SURF, Science Park 140, 1098 XG Amsterdam, The Netherlands
 
 *Claudio D'Onofrio* (claudio.donofrio@nateko.lu.se, https://orcid.org/0000-0002-1982-3889),
 ICOS Carbon Portal, Lund University, Physical Geography & Ecosystem

--- a/white-paper/authors.rst
+++ b/white-paper/authors.rst
@@ -26,6 +26,10 @@ Burckhardtweg 4, 37077 Göttingen, Germany
 GWDG, Gesellschaft für wissenschaftliche Datenverarbeitung Göttingen,
 Burckhardtweg 4, 37077 Göttingen, Germany
 
+*Tibor Kálmán* (tibor.kalman@gwdg.de, https://orcid.org/0000-0001-5194-5053),
+GWDG, Gesellschaft für wissenschaftliche Datenverarbeitung Göttingen,
+Burckhardtweg 4, 37077 Göttingen, Germany
+
 *Anita Bandrowski* (abandrowski@ucsd.edu, https://orcid.org/0000-0002-5497-0243),
 Department of Neuroscience, University of California at San Diego,
 9500 Gilman Drive La Jolla, CA 92093-0662 and SciCrunch Inc, 9500

--- a/white-paper/authors.rst
+++ b/white-paper/authors.rst
@@ -6,7 +6,9 @@ Liverpool, L3 5DA, United Kingdom
 MARUM - Center for Marine Environmental Sciences, University of Bremen, Leobener Str. 8, 28359 Bremen, Germany
 
 *Anusuriya Devaraju* (adevaraju@marum.de, https://orcid.org/0000-0003-0870-3192),
-MARUM - Center for Marine Environmental Sciences, University of Bremen, Leobener Str. 8, 28359 Bremen, Germany
+Terrestrial Ecosystem Research Network (TERN), The University of
+Queensland, Long Pocket Precinct, Level 5 Foxtail Building #1019, 80
+Meiers Road, Indooroopilly QLD 4068, Australia
 
 *Ulrich Schwardmann* (ulrich.schwardmann@gwdg.de, https://orcid.org/0000-0001-6337-8674),
 GWDG, Gesellschaft für wissenschaftliche Datenverarbeitung Göttingen,

--- a/white-paper/authors.rst
+++ b/white-paper/authors.rst
@@ -5,10 +5,8 @@ Liverpool, L3 5DA, United Kingdom
 *Robert Huber* (rhuber@uni-bremen.de, https://orcid.org/0000-0003-3000-0020),
 MARUM - Center for Marine Environmental Sciences, University of Bremen, Leobener Str. 8, 28359 Bremen, Germany
 
-*Anusuriya Devaraju* (adevaraju@marum.de, https://orcid.org/0000-0003-0870-3192),
-Terrestrial Ecosystem Research Network (TERN), The University of
-Queensland, Long Pocket Precinct, Level 5 Foxtail Building #1019, 80
-Meiers Road, Indooroopilly QLD 4068, Australia
+*Anusuriya Devaraju* (anusuriya.devaraju@csiro.au, https://orcid.org/0000-0003-0870-3192),
+CSIRO Mineral Resources, 26 Dick Perry Avenue, Kensington WA 6151, Australia
 
 *Ulrich Schwardmann* (ulrich.schwardmann@gwdg.de, https://orcid.org/0000-0001-6337-8674),
 GWDG, Gesellschaft für wissenschaftliche Datenverarbeitung Göttingen,

--- a/white-paper/authors.rst
+++ b/white-paper/authors.rst
@@ -9,8 +9,8 @@ MARUM - Center for Marine Environmental Sciences, University of Bremen, Leobener
 MARUM - Center for Marine Environmental Sciences, University of Bremen, Leobener Str. 8, 28359 Bremen, Germany
 
 *Ulrich Schwardmann* (ulrich.schwardmann@gwdg.de, https://orcid.org/0000-0001-6337-8674),
-GWDG, Gesellschaft für wissenschaftliche Datenverarbeitung Göttingen, Am
-Fassberg 11, 37077 Göttingen, Germany
+GWDG, Gesellschaft für wissenschaftliche Datenverarbeitung Göttingen,
+Burckhardtweg 4, 37077 Göttingen, Germany
 
 *Rolf Krahl* (rolf.krahl@helmholtz-berlin.de, https://orcid.org/0000-0002-1266-3819),
 Helmholtz-Zentrum Berlin für Materialien und Energie,

--- a/white-paper/authors.rst
+++ b/white-paper/authors.rst
@@ -62,7 +62,7 @@ MARUM - Center for Marine Environmental Sciences, University of Bremen, Leobener
 CSIRO Mineral Resources, 26 Dick Perry Avenue, Kensington WA 6151, Australia
 
 *Markus Stocker* (markus.stocker@tib.eu, https://orcid.org/0000-0001-5492-3212),
-TIB Leibniz Information Centre for Science and Technology,
+TIB – Leibniz Information Centre for Science and Technology,
 Welfengarten 1 B, 30167 Hannover, Germany and Leibniz University
 Hannover, Welfengarten 1, 30167 Hannover, Germany
 

--- a/white-paper/index.rst
+++ b/white-paper/index.rst
@@ -37,3 +37,11 @@ Contributors
 ~~~~~~~~~~~~
 
 .. include:: authors.rst
+
+Competing interests
+~~~~~~~~~~~~~~~~~~~
+
+Anita Bandrowski is a founder and CEO of SciCrunch Inc, a company
+devoted to working with publishers to improve the scientific
+literature.  All other authors declare that they have no competing
+interests.


### PR DESCRIPTION
Add a small [section](https://docs.pidinst.org/en/coi-statement/white-paper/index.html#competing-interests) after the author's list stating competing interests.

Note: this is based on the `update-authors` branch, so it assumes #26 to be finalized and merged first. Furthermore, we need confirmation from all authors whether this statement is correct. In particular the GWDG colleagues and Mark van de Sanden might want to state their affiliation with ePIC and B2INST respectively.