### PR TITLE
Review Read the Docs build setup

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,19 +1,19 @@
-# .readthedocs.yml
-# Read the Docs configuration file
+# Read the Docs configuration file for Sphinx projects
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+  jobs:
+    post_install:
+      - python setup.py meta
+
 sphinx:
   configuration: conf.py
-
-# For the moment, restrict to building html only.  In the long run, we
-# will want to build pdf as well, but that needs more configuration
-# tweaking to create decent results.
-formats: []
 
 python:
   install:
     - requirements: .requirements
-    - method: setuptools
-      path: .

--- a/.requirements
+++ b/.requirements
@@ -1,1 +1,3 @@
 setuptools_scm
+sphinx>=2,<3
+sphinx-rtd-theme>=0.5,<1

--- a/_static/css/spacing.css
+++ b/_static/css/spacing.css
@@ -1,0 +1,13 @@
+.rst-content .section .line-block {
+    margin-bottom: 0px;
+}
+
+.rst-content .section ol li > ol, .rst-content .section ol li > ul, .rst-content .section ul li > ol, .rst-content .section ul li > ul {
+    margin-top: 0px;
+    margin-bottom: 0px;
+}
+
+.rst-content .section td > div[class^=highlight] {
+    margin-top: 1px;
+    margin-bottom: 1px;
+}

--- a/conf.py
+++ b/conf.py
@@ -108,6 +108,7 @@ html_favicon = "images/pidinst-logo.ico"
 
 html_css_files = [
     'css/captions.css',
+    'css/spacing.css',
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,14 @@
 # This setup.py file serves the only purpose to dynamically create a
 # _meta.py file which then is imported from conf.py.
 
+import setuptools
+from setuptools import setup
+import setuptools.command.install
+from distutils import log
 import datetime
-import distutils.core
 import os
 from pathlib import Path
 import subprocess
-from setuptools import setup
-import setuptools.command.install
 
 
 class GitProps:
@@ -38,9 +39,9 @@ class GitProps:
             return datetime.date.fromtimestamp(ts)
 
 
-class meta(distutils.core.Command):
+class meta(setuptools.Command):
 
-    description = "generate a _meta.py file"
+    description = "generate meta files"
     user_options = []
     meta_template = '''
 __version__ = "%(version)s"
@@ -55,11 +56,13 @@ __date__ = "%(date)s"
 
     def run(self):
         git = GitProps()
+        version = self.distribution.get_version()
+        log.info("version: %s", version)
         values = {
-            'version': self.distribution.get_version(),
+            'version': version,
             'date': git.get_date().strftime("%e %B %Y").strip(),
         }
-        with open("_meta.py", "wt") as f:
+        with Path("_meta.py").open("wt") as f:
             print(self.meta_template % values, file=f)
 
 
@@ -71,7 +74,8 @@ class install(setuptools.command.install.install):
 
 setup(
     use_scm_version=True,
-    python_requires='>= 3.6',
-    setup_requires=['setuptools_scm'],
+    url = "https://github.com/rdawg-pidinst/white-paper",
+    python_requires = '>= 3.6',
+    install_requires = ['setuptools_scm'],
     cmdclass = {'meta': meta, 'install': install},
 )


### PR DESCRIPTION
- Review some settings in the Read the Docs build setup.  This only affects internals of the build process under the hood, but should not have any impact on the resulting documentation at RtD.
- Moderately raise the version of Sphinx being used to build the documentation. This has some minor impact on the visual appearance of the result.
- Add `spacing.css` to tweak some vertical spacing. This mends a few cases where the change in visual appearance from the last bullet was unfavourable.
