### PR TITLE
Various minor fixes

### DIFF
--- a/datacite-cookbook/prereq.rst
+++ b/datacite-cookbook/prereq.rst
@@ -1,10 +1,10 @@
 Prerequisites for minting DOIs
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-As a prerequisite to issue DataCite DOIs, your
-organization needs to be a DataCite member or work with a DataCite
-member.  This will provide you with your own DOI prefix and the access
-to `DataCite Fabrica`_ that you will need for
+As a prerequisite to issue DataCite DOIs, your organization needs to
+be a DataCite member or work with a DataCite member.  This will
+provide you with your own DOI prefix and the access to
+`DataCite Fabrica`_ that you will need for
 :ref:`datacite-cookbook-minting`.
 
 .. _DataCite Fabrica: https://doi.datacite.org/

--- a/setup.py
+++ b/setup.py
@@ -77,5 +77,6 @@ setup(
     url = "https://github.com/rdawg-pidinst/white-paper",
     python_requires = '>= 3.6',
     install_requires = ['setuptools_scm'],
+    py_modules = [],
     cmdclass = {'meta': meta, 'install': install},
 )

--- a/white-paper/adoption.rst
+++ b/white-paper/adoption.rst
@@ -24,21 +24,21 @@ user operation in the near future.
 British Oceanographic Data Centre (BODC)
 ----------------------------------------
 
-The British Oceanographic Data Centre (BODC) is a national facility for
-preserving and distributing oceanographic and marine data. BODC tested
-the ePIC implementation in web-published, sensor technical metadata
-descriptions encoded in the Open Geospatial Consortium’s (OGC)
-`SensorML`_ open standards for conceptualising and integrating
-real-world sensors. In an initial test case, a PID was minted for a
+The British Oceanographic Data Centre (BODC) is a national facility
+for preserving and distributing oceanographic and marine data.  BODC
+tested the ePIC implementation in web-published, sensor technical
+metadata descriptions encoded in the Open Geospatial Consortium’s
+(OGC) `SensorML`_ open standards for conceptualising and integrating
+real-world sensors.  In an initial test case, a PID was minted for a
 Sea-Bird Scientific SBE37 Microcat regularly deployed on fixed-point
-moorings in the `Porcupine Abyssal Plain Sustained Observatory (PAP-SO)
-<PAP-SO_>`_ in the north Atlantic. For further details see
-:ref:`landing-page-encoding-swe`. BODC plan to continue adoption
+moorings in the `Porcupine Abyssal Plain Sustained Observatory
+(PAP-SO) <PAP-SO_>`_ in the north Atlantic.  For further details see
+:ref:`landing-page-encoding-swe`.  BODC plan to continue adoption
 identifying sensors on large research vessels owned by the Natural
 Environment Research Council (NERC) and managed by the National
-Oceanography Centre (NOC) and British Antarctic Survey (BAS). PIDs will
-be used to manage sensor data and metadata workflows from ‘deck to
-desktop’ as part of a UK initiative, I/Ocean.
+Oceanography Centre (NOC) and British Antarctic Survey (BAS).  PIDs
+will be used to manage sensor data and metadata workflows from ‘deck
+to desktop’ as part of a UK initiative, I/Ocean.
 
 EISCAT3D
 --------
@@ -46,118 +46,122 @@ EISCAT3D
 `EISCAT3D`_ will be an international research infrastructure, using
 radar observations and the incoherent scatter technique for studies of
 the atmosphere and near-Earth space environment above the
-Fenno-Scandinavian Arctic as well as for the support of the solar system
-and radio astronomy sciences. EISCAT3D will implement persistent
-identification for instruments following the recommendations by PIDINST.
-The radar is complex, more digital than previous radars, and is roughly
-divided into a number of separate units. While software is a substantial
-constituent of these units, they can be regarded as hardware units, each
-persistently identified. Updates to the units will be primarily to
-software and result in new unit versions with own PIDs. The radar itself
-can also be persistently identified and the relation type HasComponent
-can be used to relate to the persistently identified units.
+Fenno-Scandinavian Arctic as well as for the support of the solar
+system and radio astronomy sciences.  EISCAT3D will implement
+persistent identification for instruments following the
+recommendations by PIDINST.  The radar is complex, more digital than
+previous radars, and is roughly divided into a number of separate
+units.  While software is a substantial constituent of these units,
+they can be regarded as hardware units, each persistently identified.
+Updates to the units will be primarily to software and result in new
+unit versions with own PIDs.  The radar itself can also be
+persistently identified and the relation type HasComponent can be used
+to relate to the persistently identified units.
 
 SENSOR.awi.de and PANGAEA
 -------------------------
 
 The Alfred Wegener Institute Helmholtz Centre for Polar and Marine
-Research (AWI) has been continuously committed to develop and sustain an
-eResearch infrastructure for coherent discovery, view, dissemination,
-and archival of scientific data and related information in polar and
-marine regions. In order to address the increasing heterogeneity of
-research platforms and respective devices and sensors along with varying
-project-driven requirements, a generic and modular framework has been
-built intended to support the flow of sensor observations to archives
-(O2A).\ [#koppe2015]_ In this context, SENSOR.awi.de, available since
-2015, is an O2A component dedicated to the registry of research
-platforms, devices and sensors and in the meantime in use by several
-international partners (e.g. MOSAiC project). SENSOR.awi.de has been
-built using OGC SensorML standard and all individual records, to date
-over 4000, are assigned a persistent identifier using UUIDs in the
-handle syntax along with automated generation of a record
-citation. Terminologies (e.g., controlled vocabularies) are used to
-define sensor categories (NERC L05) as well as sensor types and models
-(NERC L22). The data model of SENSOR.awi.de is compliant with the
-PIDINST schema and the additional implementation of Datacite DOIS for
-sensors is to date under evaluation.  The ultimate goal of SENSOR.awi.de
-is to enhance the quality of published and archived data in PANGAEA by
-providing complete metadata and persistent identifiers on instruments
-and sensors used in the data acquisition process
-(:numref:`fig-link-pangea`). Given that platforms and sensors evolve
+Research (AWI) has been continuously committed to develop and sustain
+an eResearch infrastructure for coherent discovery, view,
+dissemination, and archival of scientific data and related information
+in polar and marine regions.  In order to address the increasing
+heterogeneity of research platforms and respective devices and sensors
+along with varying project-driven requirements, a generic and modular
+framework has been built intended to support the flow of sensor
+observations to archives (O2A).\ [#koppe2015]_ In this context,
+SENSOR.awi.de, available since 2015, is an O2A component dedicated to
+the registry of research platforms, devices and sensors and in the
+meantime in use by several international partners (e.g. MOSAiC
+project).  SENSOR.awi.de has been built using OGC SensorML standard
+and all individual records, to date over 4000, are assigned a
+persistent identifier using UUIDs in the handle syntax along with
+automated generation of a record citation.  Terminologies (e.g.,
+controlled vocabularies) are used to define sensor categories (NERC
+L05) as well as sensor types and models (NERC L22).  The data model of
+SENSOR.awi.de is compliant with the PIDINST schema and the additional
+implementation of Datacite DOIS for sensors is to date under
+evaluation.  The ultimate goal of SENSOR.awi.de is to enhance the
+quality of published and archived data in PANGAEA by providing
+complete metadata and persistent identifiers on instruments and
+sensors used in the data acquisition process
+(:numref:`fig-link-pangea`).  Given that platforms and sensors evolve
 in time (sensors are being calibrated, instrument payload changes,
 etc), SENSOR.awi.de also supports record versioning by maintaining an
 audit trail of changes in the XML record.
 
-PANGAEA is a digital repository for environmental research data and the
-dedicated long term archive within the O2A framework jointly operated by
-the AWI and MARUM (University Bremen). Each dataset is made available
-with its descriptive metadata, including the relations with research
-resources (e.g., articles, funder, instrument and specimen, if
-applicable). As a data provider, PANGAEA only curates limited
-information of a device such as device name, identifier and type. As an
-effort to standardize device type and name, currently the repository
-applies external terminologies, in particular the NERC L05 device
-category vocabulary and the L22 device catalogue. The repository has
-developed tailor-made client applications to import these terminologies
-in a periodic, incremental manner. For both the persistent
-identification as well as for the detailed description of instruments,
-PANGAEA thus relies on institutional instrument registries such as
-SENSOR.awi.de and uses their issued PIDs to uniquely identify
-instruments which have been used to acquire data archived at PANGAEA.
-Since AWI and PANGAEA use the same vocabularies/terminologies as well as
-PIDs to represent devices, they facilitate easy integration of datasets
-in particular during transfer of near real time data from O2A raw data
-staging areas via data quality control services etc to their final
-destination, the PANGAEA data archive.\ [#koppe2015]_
+PANGAEA is a digital repository for environmental research data and
+the dedicated long term archive within the O2A framework jointly
+operated by the AWI and MARUM (University Bremen).  Each dataset is
+made available with its descriptive metadata, including the relations
+with research resources (e.g., articles, funder, instrument and
+specimen, if applicable).  As a data provider, PANGAEA only curates
+limited information of a device such as device name, identifier and
+type.  As an effort to standardize device type and name, currently the
+repository applies external terminologies, in particular the NERC L05
+device category vocabulary and the L22 device catalogue.  The
+repository has developed tailor-made client applications to import
+these terminologies in a periodic, incremental manner.  For both the
+persistent identification as well as for the detailed description of
+instruments, PANGAEA thus relies on institutional instrument
+registries such as SENSOR.awi.de and uses their issued PIDs to
+uniquely identify instruments which have been used to acquire data
+archived at PANGAEA.  Since AWI and PANGAEA use the same
+vocabularies/terminologies as well as PIDs to represent devices, they
+facilitate easy integration of datasets in particular during transfer
+of near real time data from O2A raw data staging areas via data
+quality control services etc to their final destination, the PANGAEA
+data archive.\ [#koppe2015]_
 
 ICOS
 ----
 
 The Integrated Carbon Observation System (ICOS) is a pan-european
-research infrastructure for quantifying and understanding the greenhouse
-gas balance of the European continent. It conducts many continuous
-in-situ measurements like gas concentrations, wind speed and direction,
-humidity, temperature, etc. To deliver high quality measurement data,
-ICOS considers the adoption of a persistent identifier for instruments a
-must for documenting data provenance and tracking calibration history.
+research infrastructure for quantifying and understanding the
+greenhouse gas balance of the European continent.  It conducts many
+continuous in-situ measurements like gas concentrations, wind speed
+and direction, humidity, temperature, etc.  To deliver high quality
+measurement data, ICOS considers the adoption of a persistent
+identifier for instruments a must for documenting data provenance and
+tracking calibration history.
 
 B2INST
 ------
 
 B2INST is a service for registering, persistently identifying and
-describing instruments. The B2INST service fills the gap especially for
-research groups or smaller communities, who might lack the capability
-to operate a registry.
+describing instruments.  The B2INST service fills the gap especially
+for research groups or smaller communities, who might lack the
+capability to operate a registry.
 
 Communities and organisations can make use of the service to FAIRify
 their instrument by registering their metadata and assigning the
-instrument a PID. This instrument-PID can then be added to research
+instrument a PID.  This instrument-PID can then be added to research
 outputs, such as journal articles and datasets.
 
 B2INST provides several generic features, like assigning PIDs and DOIs
-to the metadata, as well as presenting a landing page of the instrument
-based on the registered metadata. It also provides additional features,
-like the possibility to upload data to the registered instruments
-(such additional data can be almost everything that supports the
-description of the instrument, e.g. calibration protocols, pictures of
-the instruments, technical manuals, etc). In B2INST, the registered
-information is publicly available for everyone. Creating or maintaining
-information requires authorization - for that B2INST supports federated
-identity management, so users can use their home accounts to log in to
-the system.
+to the metadata, as well as presenting a landing page of the
+instrument based on the registered metadata.  It also provides
+additional features, like the possibility to upload data to the
+registered instruments (such additional data can be almost everything
+that supports the description of the instrument, e.g. calibration
+protocols, pictures of the instruments, technical manuals, etc).  In
+B2INST, the registered information is publicly available for everyone.
+Creating or maintaining information requires authorization - for that
+B2INST supports federated identity management, so users can use their
+home accounts to log in to the system.
 
 The identified use cases showed that communities have different
-requirements for instrument metadata. The PIDINST schema covers a
-minimum set of metadata to describe instruments only. B2INST provides
+requirements for instrument metadata.  The PIDINST schema covers a
+minimum set of metadata to describe instruments only.  B2INST provides
 community extensions; thus, it is possible to add broader descriptions
 of instruments and to support the requirements of different
-communities. Based on the PIDINST schema, communities can add metadata
-extensions to better support their community needs.
+communities.  Based on the PIDINST schema, communities can add
+metadata extensions to better support their community needs.
 
 The current plan foresees that B2INST will be offered as a public
-service by EUDAT. The initial proof-of-concept was set up by SURF. It
-was further developed by the GWDG, which will operate the service in a
-production mode.
+service by EUDAT.  The initial proof-of-concept was set up by SURF.
+It was further developed by the GWDG, which will operate the service
+in a production mode.
 
 
 .. _SensorML:

--- a/white-paper/create-new-pid.rst
+++ b/white-paper/create-new-pid.rst
@@ -24,8 +24,8 @@ for the superceded PID as shown in
 :numref:`%s <snip-create-superseding-json>`, and
 :numref:`%s <snip-create-superseded-json>`.
 
-.. _snip-create-superseding-xml:
 .. code-block:: XML
+    :name: snip-create-superseding-xml
     :caption: The use of the relatedIdentifier property to represent
 	      superseding PID records in XML
 
@@ -33,8 +33,8 @@ for the superceded PID as shown in
          <relatedIdentifier relatedIdentifierType="DOI" relationType="IsNewVersionOf">10.4232/10.CPoS-2013-02en</relatedIdentifier>
       </relatedIdentifiers>
 
-.. _snip-create-superseded-xml:
 .. code-block:: XML
+    :name: snip-create-superseded-xml
     :caption: The use of the relatedIdentifier property to represent
 	      superseded PID records in XML
 
@@ -42,8 +42,8 @@ for the superceded PID as shown in
          <relatedIdentifier relatedIdentifierType="DOI" relationType="IsPreviousVersionOf">http://hdl.handle.net/21.T11998/0000-001A-3905-F</relatedIdentifier>
       </relatedIdentifiers>
 
-.. _snip-create-superseding-json:
 .. code-block:: JSON
+    :name: snip-create-superseding-json
     :caption: The use of the relatedIdentifier property to represent
 	      superseding PID records in JSON
 
@@ -55,8 +55,8 @@ for the superceded PID as shown in
         }
       }]
 
-.. _snip-create-superseded-json:
 .. code-block:: JSON
+    :name: snip-create-superseded-json
     :caption: The use of the relatedIdentifier property to represent
 	      superseded PID records in JSON
 

--- a/white-paper/duplication.rst
+++ b/white-paper/duplication.rst
@@ -19,16 +19,16 @@ achieved using the PIDINST metadata schema *relatedIdentifier* property
 with a *relationType* attribute *IsIdenticalTo* as shown in
 :numref:`snip-dub-merge-xml` and :numref:`%s <snip-dub-merge-json>`.
 
-.. _snip-dub-merge-xml:
 .. code-block:: XML
+    :name: snip-dub-merge-xml
     :caption: Merging duplicate instrument PID records using XML
 
       <relatedIdentifiers>
          <relatedIdentifier relatedIdentifierType="DOI" relationType="IsIdenticalTo">10.4232/10.CPoS-2013-02en</relatedIdentifier>
       </relatedIdentifiers>
 
-.. _snip-dub-merge-json:
 .. code-block:: JSON
+    :name: snip-dub-merge-json
     :caption: Merging duplicate instrument PID records using JSON
 
     [{

--- a/white-paper/duplication.rst
+++ b/white-paper/duplication.rst
@@ -2,21 +2,21 @@ Dealing with duplication
 ========================
 
 Duplication between identifier records is not a new problem and is
-common to many applications (e.g. bibliographic, medical records). While
-PIDINST identifiers are considered globally persistent it is accepted
-that duplication may occur particularly where institutions loan
-instruments to other organisations or provide access to specialised
-facilities (e.g. large scale synchrotrons, medical laboratories,
-computational facilities). Such duplication may lead to inaccurate
-statistics or reporting about instrument assets.
+common to many applications (e.g. bibliographic, medical records).
+While PIDINST identifiers are considered globally persistent it is
+accepted that duplication may occur particularly where institutions
+loan instruments to other organisations or provide access to
+specialised facilities (e.g. large scale synchrotrons, medical
+laboratories, computational facilities).  Such duplication may lead to
+inaccurate statistics or reporting about instrument assets.
 
-It is recommended that owners of instruments try to employ workflows and
-procedures that avoid duplication in the first instance. Where this has
-not been possible, it is recommended that instrument owners employ
-deduplication, effectively merging duplicate records into one
-representative record by ensuring links between them. This can be
-achieved using the PIDINST metadata schema *relatedIdentifier* property
-with a *relationType* attribute *IsIdenticalTo* as shown in
+It is recommended that owners of instruments try to employ workflows
+and procedures that avoid duplication in the first instance.  Where
+this has not been possible, it is recommended that instrument owners
+employ deduplication, effectively merging duplicate records into one
+representative record by ensuring links between them.  This can be
+achieved using the PIDINST metadata schema *relatedIdentifier*
+property with a *relationType* attribute *IsIdenticalTo* as shown in
 :numref:`snip-dub-merge-xml` and :numref:`%s <snip-dub-merge-json>`.
 
 .. code-block:: XML
@@ -40,12 +40,13 @@ with a *relationType* attribute *IsIdenticalTo* as shown in
     }]
 
 Recent advances in technologies are expanding to algorithms that
-automatically detect and resolve deduplication. While such methodologies
-have been known to improve the efficiency of detection in large
-collections such as Google Scholar or OpenAire Research Graph,
-algorithms may be limited by heterogeneous representations for example,
-by the use of differing semantics. While automatic detection is
-encouraged, the PIDINST schema is designed to complement
-multidisciplinary best practices for property values and many properties
-allow for soft-typing, giving users the ability to use values of their
-choice, such as free text or domain-specific standards.
+automatically detect and resolve deduplication.  While such
+methodologies have been known to improve the efficiency of detection
+in large collections such as Google Scholar or OpenAire Research
+Graph, algorithms may be limited by heterogeneous representations for
+example, by the use of differing semantics.  While automatic detection
+is encouraged, the PIDINST schema is designed to complement
+multidisciplinary best practices for property values and many
+properties allow for soft-typing, giving users the ability to use
+values of their choice, such as free text or domain-specific
+standards.

--- a/white-paper/duplication.rst
+++ b/white-paper/duplication.rst
@@ -32,12 +32,12 @@ with a *relationType* attribute *IsIdenticalTo* as shown in
     :caption: Merging duplicate instrument PID records using JSON
 
     [{
-       "RelatedIdentifier":{
-          "RelatedIdentifierValue":"10.4232/10.CPoS-2013-02en",
-          "RelatedIdentifierType": "DOI",
-          "relationType":"IsIdenticalTo"
-          }
-      }]
+      "RelatedIdentifier":{
+        "RelatedIdentifierValue":"10.4232/10.CPoS-2013-02en",
+        "RelatedIdentifierType": "DOI",
+        "relationType":"IsIdenticalTo"
+      }
+    }]
 
 Recent advances in technologies are expanding to algorithms that
 automatically detect and resolve deduplication. While such methodologies

--- a/white-paper/landing-page-content.rst
+++ b/white-paper/landing-page-content.rst
@@ -20,10 +20,10 @@ designed to complement the administration and discovery of
 instruments; to enable users to put data into context; and to automate
 instrument metadata into data workflows.
 
-.. _tab-landing-content-inst:
 .. table:: Descriptive landing page metadata describing measuring
 	   instruments. To be used in conjunction with the core
 	   instrument metadata used in the PIDINST schema.
+    :name: tab-landing-content-inst
 
     +-------------------+-------------------------------------------------+
     | **Metadata type** | **Comments**                                    |
@@ -50,13 +50,13 @@ instrument metadata into data workflows.
     |                   | component etc.                                  |
     +-------------------+-------------------------------------------------+
 
-.. _tab-landing-content-events:
 .. table:: Descriptive, landing page metadata that describes the
 	   history of events, operations or changes during the
 	   lifetime of an instrument. This kind of metadata should be
 	   associated to dates and ideally accompanied by comments. To
 	   be used in conjunction with the core instrument metadata
 	   used in the PIDINST schema.
+    :name: tab-landing-content-events
 
     +--------------------+------------------------------------------------+
     | **Metadata type**  | **Comments**                                   |

--- a/white-paper/landing-page-encoding.rst
+++ b/white-paper/landing-page-encoding.rst
@@ -43,8 +43,8 @@ respective representation in JSON-LD of the schema example shown in
 :numref:`tab-schema-handle-record` is shown in
 :numref:`snip-landing-encoding-json-ld`.
 
-.. _snip-landing-encoding-json-ld:
 .. code-block:: JSON
+    :name: snip-landing-encoding-json-ld
     :caption: representation in JSON-LD of the example of
 	      :numref:`tab-schema-handle-record`.
 
@@ -199,8 +199,8 @@ that results into the following serialization
 and the names used in the type definitions are replaced by their type
 PID suffixes:
 
-.. _snip-landing-encoding-turtle:
 .. code-block:: turtle
+    :name: snip-landing-encoding-turtle
     :caption: representation in Turtle Terse RDF of the NERC example
 	      of :numref:`tab-schema-handle-record` that was generated
 	      by a JSON-LD to RDF converter from the JSON-LD in
@@ -278,8 +278,8 @@ instrument PIDs can be found indirectly using a combination of
 *GetCapabilities* and *DescribeSensor* operational requests to a SOS
 server.
 
-.. _snip-landing-encoding-sensorml:
 .. code-block:: xml
+    :name: snip-landing-encoding-sensorml
     :caption: An example of expressing an instrument PID
 	      (http://hdl.handle.net/21.T11998/0000-001A-3905-F) as
 	      identifying metadata within a SensorML technical

--- a/white-paper/landing-page-encoding.rst
+++ b/white-paper/landing-page-encoding.rst
@@ -48,142 +48,142 @@ respective representation in JSON-LD of the schema example shown in
     :caption: representation in JSON-LD of the example of
 	      :numref:`tab-schema-handle-record`.
 
-        {
+      {
         "@context" : {
-         "ARK-Identifier" : "dti:21.T11148/7af6f46512fb4c190d01",
-         "AlternateIdentifier" : "dti:21.T11148/d87a75c52c68b06e9a18",
-         "AlternateIdentifierValue" : "dti:21.T11148/38330bcc6a40ca85e5b4",
-         "AlternateIdentifiers" : "dti:21.T11148/eb3c713572f681e6c4c3",
-         "Bibcode-Identifier" : "dti:21.T11148/6c2fc7682e48ac7160b5",
-         "DOI-Identifier-General" : "dti:21.T11148/d93427e3c56173e9dc08",
-         "Date" : "dti:21.T11148/eb9a4bc1c0c153e4e4b0",
-         "Dates" : "dti:21.T11148/22c62082a4d2d9ae2602",
-         "Description" : "dti:21.T11148/55f8ebc805e65b5b71dd",
-         "Handle-Identifier-ASCII" : "dti:21.T11148/3626040cadcac1571685",
-         "ISAN-Identifier" : "dti:21.T11148/48cfce4482166a103c50",
-         "ISBN-Identifier" : "dti:21.T11148/2ff8ad6cdd4e46622944",
-         "ISNI-Identifier" : "dti:21.T11148/cff32964e132c14fc56f",
-         "ISRC-Identifier" : "dti:21.T11148/2719170925ff2bfb5157",
-         "ISSN-Identifier" : "dti:21.T11148/7e689432354610f388c0",
-         "ISTC-Identifier" : "dti:21.T11148/1f0df9ef66774b2e2aa1",
-         "ISWC-Identifier" : "dti:21.T11148/698fba7e1c659fcfdcdd",
-         "InstrumentType" : "dti:21.T11148/f76ad9d0324302fc47dd",
-         "LandingPage" : "dti:21.T11148/9a15a4735d4bda329d80",
-         "Manufacturer" : "dti:21.T11148/7adfcd13b3b01de0d875",
-         "Manufacturers" : "dti:21.T11148/1f3e82ddf0697a497432",
-         "MeasuredVariable" : "dti:21.T11148/1fcb0dad9aced457d67e",
-         "MeasuredVariables" : "dti:21.T11148/72928b84e060d491ee41",
-         "Name" : "dti:21.T11148/709a23220f2c3d64d1e1",
-         "Owner" : "dti:21.T11148/89ff31225c5f042fff61",
-         "Owners" : "dti:21.T11148/4eaec4bc0f1df68ab2a7",
-         "PMCID-Identifier" : "dti:21.T11148/e94bec7d7f1c63dd00cd",
-         "PMID-Identifier" : "dti:21.T11148/234c084bac48480bfe5d",
-         "RelatedIdentifier" : "dti:21.T11148/ec9f00af0761a065dbd0",
-         "RelatedIdentifierType" : "dti:21.T11148/015dc79a77940fb65aa4",
-         "RelatedIdentifierValue" : "dti:21.T11148/38330bcc6a40ca85e5b4",
-         "RelatedIdentifiers" : "dti:21.T11148/178fb558abc755ca7046",
-         "URN-Identifier" : "dti:21.T11148/d22b6854df3503df7831",
-         "VariableMeasured" : "dti:21.T11148/f1627ce85386d8d75078",
-         "alternateIdentifierType" : "dti:21.T11148/015dc79a77940fb65aa4",
-         "arXiv-Identifier" : "dti:21.T11148/d66f8368c3d305941a2e",
-         "date" : "dti:21.T11148/be707495360a234ef049",
-         "dateType" : "dti:21.T11148/2f0e608b621a5a97e0d9",
-         "dti" : "http://hdl.handle.net/",
-         "identifier-general-with-type" : "dti:21.T11148/8eb858ee0b12e8e463a5",
-         "identifierType" : "dti:21.T11148/015dc79a77940fb65aa4",
-         "identifierValue" : "dti:21.T11148/38330bcc6a40ca85e5b4",
-         "manufacturerIdentifier" : "dti:21.T11148/5b240e16ea32ea25cf65",
-         "manufacturerIdentifierType" : "dti:21.T11148/015dc79a77940fb65aa4",
-         "manufacturerIdentifierValue" : "dti:21.T11148/38330bcc6a40ca85e5b4",
-         "manufacturerName" : "dti:21.T11148/798588c5a1ec532f737b",
-         "modelName" : "dti:21.T11148/798588c5a1ec532f737b",
-         "other" : "dti:21.T11148/f40cb15558a7c1546c91",
-         "ownerContact" : "dti:21.T11148/a88b7dcd1a9e3e17770b",
-         "ownerIdentifier" : "dti:21.T11148/1e3c17ac2a3e7ebf466a",
-         "ownerIdentifierType" : "dti:21.T11148/015dc79a77940fb65aa4",
-         "ownerIdentifierValue" : "dti:21.T11148/38330bcc6a40ca85e5b4",
-         "ownerName" : "dti:21.T11148/798588c5a1ec532f737b",
-         "relationType" : "dti:21.T11148/292a53bd9ee27a242082"
+          "ARK-Identifier" : "dti:21.T11148/7af6f46512fb4c190d01",
+          "AlternateIdentifier" : "dti:21.T11148/d87a75c52c68b06e9a18",
+          "AlternateIdentifierValue" : "dti:21.T11148/38330bcc6a40ca85e5b4",
+          "AlternateIdentifiers" : "dti:21.T11148/eb3c713572f681e6c4c3",
+          "Bibcode-Identifier" : "dti:21.T11148/6c2fc7682e48ac7160b5",
+          "DOI-Identifier-General" : "dti:21.T11148/d93427e3c56173e9dc08",
+          "Date" : "dti:21.T11148/eb9a4bc1c0c153e4e4b0",
+          "Dates" : "dti:21.T11148/22c62082a4d2d9ae2602",
+          "Description" : "dti:21.T11148/55f8ebc805e65b5b71dd",
+          "Handle-Identifier-ASCII" : "dti:21.T11148/3626040cadcac1571685",
+          "ISAN-Identifier" : "dti:21.T11148/48cfce4482166a103c50",
+          "ISBN-Identifier" : "dti:21.T11148/2ff8ad6cdd4e46622944",
+          "ISNI-Identifier" : "dti:21.T11148/cff32964e132c14fc56f",
+          "ISRC-Identifier" : "dti:21.T11148/2719170925ff2bfb5157",
+          "ISSN-Identifier" : "dti:21.T11148/7e689432354610f388c0",
+          "ISTC-Identifier" : "dti:21.T11148/1f0df9ef66774b2e2aa1",
+          "ISWC-Identifier" : "dti:21.T11148/698fba7e1c659fcfdcdd",
+          "InstrumentType" : "dti:21.T11148/f76ad9d0324302fc47dd",
+          "LandingPage" : "dti:21.T11148/9a15a4735d4bda329d80",
+          "Manufacturer" : "dti:21.T11148/7adfcd13b3b01de0d875",
+          "Manufacturers" : "dti:21.T11148/1f3e82ddf0697a497432",
+          "MeasuredVariable" : "dti:21.T11148/1fcb0dad9aced457d67e",
+          "MeasuredVariables" : "dti:21.T11148/72928b84e060d491ee41",
+          "Name" : "dti:21.T11148/709a23220f2c3d64d1e1",
+          "Owner" : "dti:21.T11148/89ff31225c5f042fff61",
+          "Owners" : "dti:21.T11148/4eaec4bc0f1df68ab2a7",
+          "PMCID-Identifier" : "dti:21.T11148/e94bec7d7f1c63dd00cd",
+          "PMID-Identifier" : "dti:21.T11148/234c084bac48480bfe5d",
+          "RelatedIdentifier" : "dti:21.T11148/ec9f00af0761a065dbd0",
+          "RelatedIdentifierType" : "dti:21.T11148/015dc79a77940fb65aa4",
+          "RelatedIdentifierValue" : "dti:21.T11148/38330bcc6a40ca85e5b4",
+          "RelatedIdentifiers" : "dti:21.T11148/178fb558abc755ca7046",
+          "URN-Identifier" : "dti:21.T11148/d22b6854df3503df7831",
+          "VariableMeasured" : "dti:21.T11148/f1627ce85386d8d75078",
+          "alternateIdentifierType" : "dti:21.T11148/015dc79a77940fb65aa4",
+          "arXiv-Identifier" : "dti:21.T11148/d66f8368c3d305941a2e",
+          "date" : "dti:21.T11148/be707495360a234ef049",
+          "dateType" : "dti:21.T11148/2f0e608b621a5a97e0d9",
+          "dti" : "http://hdl.handle.net/",
+          "identifier-general-with-type" : "dti:21.T11148/8eb858ee0b12e8e463a5",
+          "identifierType" : "dti:21.T11148/015dc79a77940fb65aa4",
+          "identifierValue" : "dti:21.T11148/38330bcc6a40ca85e5b4",
+          "manufacturerIdentifier" : "dti:21.T11148/5b240e16ea32ea25cf65",
+          "manufacturerIdentifierType" : "dti:21.T11148/015dc79a77940fb65aa4",
+          "manufacturerIdentifierValue" : "dti:21.T11148/38330bcc6a40ca85e5b4",
+          "manufacturerName" : "dti:21.T11148/798588c5a1ec532f737b",
+          "modelName" : "dti:21.T11148/798588c5a1ec532f737b",
+          "other" : "dti:21.T11148/f40cb15558a7c1546c91",
+          "ownerContact" : "dti:21.T11148/a88b7dcd1a9e3e17770b",
+          "ownerIdentifier" : "dti:21.T11148/1e3c17ac2a3e7ebf466a",
+          "ownerIdentifierType" : "dti:21.T11148/015dc79a77940fb65aa4",
+          "ownerIdentifierValue" : "dti:21.T11148/38330bcc6a40ca85e5b4",
+          "ownerName" : "dti:21.T11148/798588c5a1ec532f737b",
+          "relationType" : "dti:21.T11148/292a53bd9ee27a242082"
         },
         "@id" : "dti:21.T11998/0000-001A-3905-F",
         "AlternateIdentifiers" : [
-         {
-         "AlternateIdentifier" : {
-            "AlternateIdentifierValue" : "2490",
-            "alternateIdentifierType" : "serialNumber"
-         }
-         }
+          {
+            "AlternateIdentifier" : {
+              "AlternateIdentifierValue" : "2490",
+              "alternateIdentifierType" : "serialNumber"
+            }
+          }
         ],
         "Dates" : [
-         {
-         "date" : {
-            "date" : "1999-11-01",
-            "dateType" : "Commissioned"
-         }
-         }
+          {
+            "date" : {
+              "date" : "1999-11-01",
+              "dateType" : "Commissioned"
+            }
+          }
         ],
         "Description" : "A high accuracy conductivity and temperature recorder with an optional pressure sensor designed for deployment on moorings. The IM model has an inductive modem for real-time data transmission plus internal flash memory data storage.",
         "InstrumentType" : "http://vocab.nerc.ac.uk/collection/L22/current/TOOL0022/",
         "LandingPage" : "https://linkedsystems.uk/system/instance/TOOL0022_2490/current/",
         "Manufacturers" : [
-         {
-         "Manufacturer" : {
-            "manufacturerIdentifier" : {
-               "manufacturerIdentifierType" : "URL",
-               "manufacturerIdentifierValue" : "http://vocab.nerc.ac.uk/collection/L35/current/MAN0013/"
-            },
-            "manufacturerName" : "Sea-Bird Scientific",
-            "modelName" : "SBE 37-IM"
-         }
-         }
+          {
+            "Manufacturer" : {
+              "manufacturerIdentifier" : {
+		"manufacturerIdentifierType" : "URL",
+		"manufacturerIdentifierValue" : "http://vocab.nerc.ac.uk/collection/L35/current/MAN0013/"
+              },
+              "manufacturerName" : "Sea-Bird Scientific",
+              "modelName" : "SBE 37-IM"
+            }
+          }
         ],
         "MeasuredVariables" : [
-         {
-         "MeasuredVariable" : {
-            "VariableMeasured" : "http://vocab.nerc.ac.uk/collection/P01/current/CNDCPR01/"
-         }
-         },
-         {
-         "MeasuredVariable" : {
-            "VariableMeasured" : "http://vocab.nerc.ac.uk/collection/P01/current/PSALPR01/"
-         }
-         },
-         {
-         "MeasuredVariable" : {
-            "VariableMeasured" : "http://vocab.nerc.ac.uk/collection/P01/current/TEMPPR01/"
-         }
-         },
-         {
-         "MeasuredVariable" : {
-            "VariableMeasured" : "http://vocab.nerc.ac.uk/collection/P01/current/PREXMCAT/"
-         }
-         }
+          {
+            "MeasuredVariable" : {
+              "VariableMeasured" : "http://vocab.nerc.ac.uk/collection/P01/current/CNDCPR01/"
+            }
+          },
+          {
+            "MeasuredVariable" : {
+              "VariableMeasured" : "http://vocab.nerc.ac.uk/collection/P01/current/PSALPR01/"
+            }
+          },
+          {
+            "MeasuredVariable" : {
+              "VariableMeasured" : "http://vocab.nerc.ac.uk/collection/P01/current/TEMPPR01/"
+            }
+          },
+          {
+            "MeasuredVariable" : {
+              "VariableMeasured" : "http://vocab.nerc.ac.uk/collection/P01/current/PREXMCAT/"
+            }
+          }
         ],
         "Name" : "Sea-Bird SBE 37-IM MicroCAT C-T Sensor",
         "Owners" : [
-         {
-         "Owner" : {
-            "ownerContact" : "louise.darroch@bodc.ac.uk",
-            "ownerIdentifier" : {
-               "ownerIdentifierType" : "URL",
-               "ownerIdentifierValue" : "http://vocab.nerc.ac.uk/collection/B75/current/ORG00009/"
-            },
-            "ownerName" : "National Oceanography Centre"
-         }
-         }
+          {
+            "Owner" : {
+              "ownerContact" : "louise.darroch@bodc.ac.uk",
+              "ownerIdentifier" : {
+		"ownerIdentifierType" : "URL",
+		"ownerIdentifierValue" : "http://vocab.nerc.ac.uk/collection/B75/current/ORG00009/"
+              },
+              "ownerName" : "National Oceanography Centre"
+            }
+          }
         ],
         "RelatedIdentifiers" : [
-         {
-         "RelatedIdentifier" : {
-            "RelatedIdentifierType" : "URL",
-            "RelatedIdentifierValue" : "https://www.bodc.ac.uk/data/documents/nodb/pdf/37imbrochurejul08.pdf",
-            "relationType" : "IsDescribedBy "
-         }
-         }
+          {
+            "RelatedIdentifier" : {
+              "RelatedIdentifierType" : "URL",
+              "RelatedIdentifierValue" : "https://www.bodc.ac.uk/data/documents/nodb/pdf/37imbrochurejul08.pdf",
+              "relationType" : "IsDescribedBy "
+            }
+          }
         ],
         "identifier-general-with-type" : {
-         "identiferType" : "MeasuringInstrument",
-         "identifierValue" : "http://hdl.handle.net/21.T11998/0000-001A-3905-F"
+          "identiferType" : "MeasuringInstrument",
+          "identifierValue" : "http://hdl.handle.net/21.T11998/0000-001A-3905-F"
         }
       }
 

--- a/white-paper/linking-datasets.rst
+++ b/white-paper/linking-datasets.rst
@@ -22,15 +22,15 @@ the instrument.  :numref:`snip-link-dataset-datacite-xml` shows a
 section of the DOI metadata from the same data publication containing
 this link.
 
-.. _fig-link-hzb:
 .. figure:: /images/ND000001-landing.png
+    :name: fig-link-hzb
     :alt: HZB dataset
 
     Landing page of a dataset published by HZB which links the PID of
     the instrument.
 
-.. _snip-link-dataset-datacite-xml:
 .. code-block:: XML
+    :name: snip-link-dataset-datacite-xml
     :caption: Use of the relatedIdentifier property in the DOI
 	      metadata from a data publication.  The second entry links
 	      the PID of the instrument.
@@ -66,22 +66,22 @@ event. As such, new types and properties are required to support the
 description of observation events and related scientific instruments
 to ensure full compliance with Schema.org functionality.
 
-.. _fig-link-pangea:
 .. figure:: /images/image2.png
+    :name: fig-link-pangea
     :alt: PANGAEA dataset
 
     An example of a dataset published by PANGAEA which includes its
     instrument identifier
     (https://doi.pangaea.de/10013/sensor.664525cf-45b9-4969-bb88-91a1c5e97a5b)
 
-.. _fig-link-model:
 .. figure:: /images/image1.png
+    :name: fig-link-model
     :alt: Conceptual model
 
     Conceptual model of Event and Specific Instrument Type (Vehicle)
 
-.. _fig-link-schema-org:
 .. figure:: /images/image3.png
+    :name: fig-link-schema-org
     :alt: Schema.org
 
     Snippet of schema.org representation of event and instrument
@@ -120,8 +120,8 @@ groups, other information relating to parameter streams or instruments
 could be expressed, such as calibralibrations and instrument reference
 frames and orientations.
 
-.. _snip-link-netcdf-cdl:
 .. code-block:: default
+    :name: snip-link-netcdf-cdl
     :caption: Truncated CF-NetCDF4 CDL file. Note some terminologies
 	      are in development.
 
@@ -212,8 +212,8 @@ instrument identifier may be expressed as an instrument attribute e.g.
 :numref:`snip-link-pidinst-netcdf`. Ideally, blank separated lists
 should be used if linking more than one instrument.
 
-.. _snip-link-pidinst-netcdf:
 .. code-block:: default
+    :name: snip-link-pidinst-netcdf
     :caption: Addition of a instrument PID attribute to NCEI CF-NetCDF
 	      files.
 

--- a/white-paper/metadata-schema-recommendations.rst
+++ b/white-paper/metadata-schema-recommendations.rst
@@ -36,7 +36,6 @@ marine domain (`http://vocab.nerc.ac.uk/collection/L22/current/ <http://vocab.ne
 An example of the use of common terminologies in ePIC records is shown
 in :numref:`tab-schema-handle-record`.
 
-.. _tab-schema-handle-record:
 .. table:: Handle record of instrument identifier
 	   http://hdl.handle.net/21.T11998/0000-001A-3905-F displaying
 	   the use of common terminologies to identify instrument
@@ -46,6 +45,7 @@ in :numref:`tab-schema-handle-record`.
 	   metadata property is provided in JSON. The Handle record
 	   can be viewed at
 	   http://hdl.handle.net/21.T11998/0000-001A-3905-F?noredirect
+    :name: tab-schema-handle-record
 
     +------------------------------------+--------------------------------------------------------------------------------------------------------------+
     | Type                               | Data                                                                                                         |
@@ -243,8 +243,8 @@ reproducibility checklist, resolved by identifiers.org and the n2t
 resolver and echoed by some of the major reagent providers (e.g., Thermo
 Fisher, Addgene, and the MMRRC mouse repository).
 
-.. _tab-schema-use-rrid:
 .. table:: Example showing the use of RRIDs in the PIDINST metadata schema.
+    :name: tab-schema-use-rrid
 
     +----------+------------------------+---------------+---------+----------------------------------------------------+--------------------------------------------+
     |          |                        |               |         |                                                    |                                            |
@@ -293,8 +293,8 @@ give a reason why it is missing.  For this purpose, PIDINST adopts the
 *standard values for unknown information* from DataCite, see Appendix
 3 in the DataCite Metadata Schema Documentation. [#datacite2019]_
 
-.. _snip-schema-unknown-xml:
 .. code-block:: XML
+    :name: snip-schema-unknown-xml
     :caption: Encoding unknown values in the instrument PID metadata using XML
 
       <name>:tba</name>

--- a/white-paper/metadata-schema-recommendations.rst
+++ b/white-paper/metadata-schema-recommendations.rst
@@ -3,10 +3,10 @@
 Recommendations using the PIDINST metadata schema
 =================================================
 
-We recommend that an instrument’s associated metadata is published in a common language,
-specifically US English to enable its reuse.  In the following section, we provide
-advanced recommendations on how to specify the values in the PIDINST
-metadata and discuss special cases.
+We recommend that an instrument’s associated metadata is published in
+a common language, specifically US English to enable its reuse.  In
+the following section, we provide advanced recommendations on how to
+specify the values in the PIDINST metadata and discuss special cases.
 
 .. _pidinst-metadata-schema-terminologies:
 
@@ -16,22 +16,23 @@ Using common terminologies
 Common terminologies such as controlled vocabularies, taxonomies or
 ontologies, are sets of standardised terms that solve the problem of
 ambiguities associated with metadata markup and enable records to be
-shared and interpreted semantically by computers. Many terminologies
+shared and interpreted semantically by computers.  Many terminologies
 exist, covering a broad spectrum of disciplines and their best
-practices. The PIDINST schema is designed to complement
-multidisciplinary best practices for property values. Many properties
+practices.  The PIDINST schema is designed to complement
+multidisciplinary best practices for property values.  Many properties
 allow for soft-typing (e.g., *ownerName*), giving users the ability to
 use values of their choice, such as free text or domain-specific
-terminologies. Property attributes enable users and machines to
+terminologies.  Property attributes enable users and machines to
 understand the context of the value (e.g., *ownerIdentifier*,
 *ownerIdentifierType*), again using free text or standardised
-terminologies. While free text is allowed, institutions should consider
-using common terminologies where practical to enhance the (semantic)
-interoperability of PID records, particularly where they form part of
-domain-specific best practice. For example, a comprehensive set of
-terminologies that describe *instrumentType* (via *instrumentTypeIdentifier*) or 
-*Model* (via *modelIdentifier*) are used widely in the Earth science
-marine domain (`http://vocab.nerc.ac.uk/collection/L22/current/ <http://vocab.nerc.ac.uk/collection/L22/current/>`_,
+terminologies.  While free text is allowed, institutions should
+consider using common terminologies where practical to enhance the
+(semantic) interoperability of PID records, particularly where they
+form part of domain-specific best practice.  For example, a
+comprehensive set of terminologies that describe *instrumentType* (via
+*instrumentTypeIdentifier*) or *Model* (via *modelIdentifier*) are
+used widely in the Earth science marine domain
+(`http://vocab.nerc.ac.uk/collection/L22/current/ <http://vocab.nerc.ac.uk/collection/L22/current/>`_,
 `http://vocab.nerc.ac.uk/collection/L05/current/ <http://vocab.nerc.ac.uk/collection/L05/current/>`_).
 An example of the use of common terminologies in ePIC records is shown
 in :numref:`tab-schema-handle-record`.
@@ -40,9 +41,9 @@ in :numref:`tab-schema-handle-record`.
 	   http://hdl.handle.net/21.T11998/0000-001A-3905-F displaying
 	   the use of common terminologies to identify instrument
 	   metadata compliant with the PIDINST schema as implemented
-	   by ePIC. The terminologies used are published on the `NERC
-	   Vocabulary Server (NVS) <NVS_>`_. The data for each
-	   metadata property is provided in JSON. The Handle record
+	   by ePIC.  The terminologies used are published on the `NERC
+	   Vocabulary Server (NVS) <NVS_>`_.  The data for each
+	   metadata property is provided in JSON.  The Handle record
 	   can be viewed at
 	   http://hdl.handle.net/21.T11998/0000-001A-3905-F?noredirect
     :name: tab-schema-handle-record
@@ -218,31 +219,32 @@ RRIDs
 
 In a similar way to common terminologies, persistent identifiers have
 been created to help users classify and accurately describe physical
-objects.  The research resource identifier (RRID) can be used to identify 
-classes of instruments (models) and is thus related to PIDINST, which 
-identifies instrument instances.\ [#bandrowski2016]_ This work is undertaken 
-by the `UsedIT`_ group, which is extending the RRID to instrument classes 
-that could be used to describe the *Model* (via *modelIdentifier*) property
-(:numref:`tab-schema-use-rrid`).  RRIDs are not described in detail
-here, but it is envisioned that the RRID metadata schema, which was
-described in detail previously,\ [#bandrowski2012]_ and extended by
-UsedIT, will be interoperable with instrument instance (PIDINST) PIDs.
-This interoperability should enable any project to quickly download
-data about the model to consistently fill mapped fields.
+objects.  The research resource identifier (RRID) can be used to
+identify classes of instruments (models) and is thus related to
+PIDINST, which identifies instrument instances.\ [#bandrowski2016]_
+This work is undertaken by the `UsedIT`_ group, which is extending the
+RRID to instrument classes that could be used to describe the *Model*
+(via *modelIdentifier*) property (:numref:`tab-schema-use-rrid`).
+RRIDs are not described in detail here, but it is envisioned that the
+RRID metadata schema, which was described in detail
+previously,\ [#bandrowski2012]_ and extended by UsedIT, will be
+interoperable with instrument instance (PIDINST) PIDs.  This
+interoperability should enable any project to quickly download data
+about the model to consistently fill mapped fields.
 
 Why RRIDs? RRIDs are currently used in about 1000 journals to tag
 classes of research resources (including reagents like antibodies or
 plasmids, organisms, cell lines, and a relatively broad category of
 “tools” which includes software tools and services such as university
 core facilities, but recently has been extended to physical tools such
-as models of sequencers or microscopes). Because RRIDs were created as
-an agreement between a group of biological journals and the National
-Institutes of Health, they are most commonly found and linked in the
-biological sciences literature (e.g., Cell, eLife), they are part of the
-JATS NISO standard, STAR Methods, and the MDAR pan-publisher
-reproducibility checklist, resolved by identifiers.org and the n2t
-resolver and echoed by some of the major reagent providers (e.g., Thermo
-Fisher, Addgene, and the MMRRC mouse repository).
+as models of sequencers or microscopes).  Because RRIDs were created
+as an agreement between a group of biological journals and the
+National Institutes of Health, they are most commonly found and linked
+in the biological sciences literature (e.g., Cell, eLife), they are
+part of the JATS NISO standard, STAR Methods, and the MDAR
+pan-publisher reproducibility checklist, resolved by identifiers.org
+and the n2t resolver and echoed by some of the major reagent providers
+(e.g., Thermo Fisher, Addgene, and the MMRRC mouse repository).
 
 .. table:: Example showing the use of RRIDs in the PIDINST metadata schema.
     :name: tab-schema-use-rrid

--- a/white-paper/metadata-schema-recommendations.rst
+++ b/white-paper/metadata-schema-recommendations.rst
@@ -46,6 +46,7 @@ in :numref:`tab-schema-handle-record`.
 	   can be viewed at
 	   http://hdl.handle.net/21.T11998/0000-001A-3905-F?noredirect
     :name: tab-schema-handle-record
+    :class: longtable
 
     +------------------------------------+--------------------------------------------------------------------------------------------------------------+
     | Type                               | Data                                                                                                         |

--- a/white-paper/metadata-schema-recommendations.rst
+++ b/white-paper/metadata-schema-recommendations.rst
@@ -294,7 +294,7 @@ In all these cases it is still useful to make it at least explicit
 that this information has not been omitted inadvertently and also to
 give a reason why it is missing.  For this purpose, PIDINST adopts the
 *standard values for unknown information* from DataCite, see Appendix
-3 in the DataCite Metadata Schema Documentation. [#datacite2019]_
+3 in the DataCite Metadata Schema Documentation.\ [#datacite2019]_
 
 .. code-block:: XML
     :name: snip-schema-unknown-xml

--- a/white-paper/metadata-schema-recommendations.rst
+++ b/white-paper/metadata-schema-recommendations.rst
@@ -84,8 +84,8 @@ in :numref:`tab-schema-handle-record`.
     |                                    |           "ownerIdentifierValue":                                                                            |
     |                                    |             "http://vocab.nerc.ac.uk/collection/B75/current/ORG00009/",                                      |
     |                                    |           "ownerIdentifierType":"URL"                                                                        |
-    |                                    |          }                                                                                                   |
-    |                                    |        }                                                                                                     |
+    |                                    |         }                                                                                                    |
+    |                                    |       }                                                                                                      |
     |                                    |     }]                                                                                                       |
     +------------------------------------+--------------------------------------------------------------------------------------------------------------+
     | | 21.T11148/1f3e82ddf0697a497432   | .. code-block:: JSON                                                                                         |
@@ -104,12 +104,12 @@ in :numref:`tab-schema-handle-record`.
     | | 21.T11148/c1a0ec5ad347427f25d6   | .. code-block:: JSON                                                                                         |
     | | (Model)                          |                                                                                                              |
     |                                    |     [{                                                                                                       |
-    |                                    |        "modelName":"Sea-Bird SBE 37 MicroCat IM-CT with optional pressure (submersible) CTD sensor series",  |
-    |                                    |        "modelIdentifier":{                                                                                   |
-    |                                    |          "modelIdentifierValue":                                                                             |
-    |                                    |            "http://vocab.nerc.ac.uk/collection/L22/current/TOOL0022/",                                       |
-    |                                    |          "modelIdentifierType":"URL"                                                                         |
-    |                                    |        }                                                                                                     |
+    |                                    |       "modelName":"Sea-Bird SBE 37 MicroCat IM-CT with optional pressure (submersible) CTD sensor series",   |
+    |                                    |       "modelIdentifier":{                                                                                    |
+    |                                    |         "modelIdentifierValue":                                                                              |
+    |                                    |           "http://vocab.nerc.ac.uk/collection/L22/current/TOOL0022/",                                        |
+    |                                    |         "modelIdentifierType":"URL"                                                                          |
+    |                                    |       }                                                                                                      |
     |                                    |     }]                                                                                                       |
     +------------------------------------+--------------------------------------------------------------------------------------------------------------+
     | | 21.T11148/55f8ebc805e65b5b71dd   | .. code-block:: JSON                                                                                         |
@@ -122,19 +122,19 @@ in :numref:`tab-schema-handle-record`.
     | | 21.T11148/f76ad9d0324302fc47dd   | .. code-block:: JSON                                                                                         |
     | | (InstrumentType)                 |                                                                                                              |
     |                                    |     [{                                                                                                       |
-    |                                    |        "instrumentTypeName":"water temperature sensor",                                                      |
-    |                                    |        "instrumentTypeIdentifier":{                                                                          |
-    |                                    |          "instrumentTypeIdentifierValue":                                                                    |
-    |                                    |            "http://vocab.nerc.ac.uk/collection/L05/current/134/",                                            |
-    |                                    |          "instrumentTypeIdentifierType":"URL"                                                                |
-    |                                    |        }                                                                                                     |
+    |                                    |       "instrumentTypeName":"water temperature sensor",                                                       |
+    |                                    |       "instrumentTypeIdentifier":{                                                                           |
+    |                                    |         "instrumentTypeIdentifierValue":                                                                     |
+    |                                    |           "http://vocab.nerc.ac.uk/collection/L05/current/134/",                                             |
+    |                                    |         "instrumentTypeIdentifierType":"URL"                                                                 |
+    |                                    |       }                                                                                                      |
     |                                    |     },{                                                                                                      |
-    |                                    |        "instrumentTypeName":"salinity sensor",                                                               |
-    |                                    |        "instrumentTypeIdentifier":{                                                                          |
-    |                                    |          "instrumentTypeIdentifierValue":                                                                    |
-    |                                    |            "http://vocab.nerc.ac.uk/collection/L05/current/350/",                                            |
-    |                                    |          "instrumentTypeIdentifierType":"URL"                                                                |
-    |                                    |        }                                                                                                     |
+    |                                    |       "instrumentTypeName":"salinity sensor",                                                                |
+    |                                    |       "instrumentTypeIdentifier":{                                                                           |
+    |                                    |         "instrumentTypeIdentifierValue":                                                                     |
+    |                                    |           "http://vocab.nerc.ac.uk/collection/L05/current/350/",                                             |
+    |                                    |         "instrumentTypeIdentifierType":"URL"                                                                 |
+    |                                    |       }                                                                                                      |
     |                                    |     }]                                                                                                       |                    
     +------------------------------------+--------------------------------------------------------------------------------------------------------------+
     | | 21.T11148/72928b84e060d491ee41   | .. code-block:: JSON                                                                                         |

--- a/white-paper/metadata-schema.rst
+++ b/white-paper/metadata-schema.rst
@@ -10,7 +10,7 @@ related resources to the instrument, thus providing a means to
 aggregate information about the instrument.  The PIDINST working group
 defined a schema of metadata that can be registered alongside
 instrument PIDs at PID providers to help meet these criteria.  Version
-1.0 has been endorsed as an RDA recommendation\ [#pidinst2022v1_0]_.
+1.0 has been endorsed as an RDA recommendation.\ [#pidinst2022v1_0]_
 
 Currently, two variants of the metadata schema exist.  The original
 `PIDINST schema`_, based on the evaluation of use cases collected by

--- a/white-paper/metadata-schema.rst
+++ b/white-paper/metadata-schema.rst
@@ -4,13 +4,13 @@ PIDINST metadata schema
 =======================
 
 The metadata that is to be registered with an instrument PID needs to
-contain enough information to unambiguously identify the
-instrument across networks and infrastructures. It should also allow
-linking related resources to the instrument, thus providing a means
-to aggregate information about the instrument. The PIDINST working group defined 
-a schema of metadata that can be registered alongside instrument PIDs at 
-PID providers to help meet these criteria. Version 1.0 has been endorsed
-as an RDA recommendation\ [#pidinst2022v1_0]_.
+contain enough information to unambiguously identify the instrument
+across networks and infrastructures.  It should also allow linking
+related resources to the instrument, thus providing a means to
+aggregate information about the instrument.  The PIDINST working group
+defined a schema of metadata that can be registered alongside
+instrument PIDs at PID providers to help meet these criteria.  Version
+1.0 has been endorsed as an RDA recommendation\ [#pidinst2022v1_0]_.
 
 Currently, two variants of the metadata schema exist.  The original
 `PIDINST schema`_, based on the evaluation of use cases collected by
@@ -22,9 +22,9 @@ describe the properties in the original PIDINST schema and discuss
 their semantics:
 
 `Identifier`
-  The PID of the instrument.  The subproperty
-  `identifierType` contains the type of the PID, e.g. `Handle` or
-  `DOI` in the case of an ePIC Handle or a DataCite DOI respectively.
+  The PID of the instrument.  The subproperty `identifierType`
+  contains the type of the PID, e.g. `Handle` or `DOI` in the case of
+  an ePIC Handle or a DataCite DOI respectively.
 
 `SchemaVersion`
   The version number of the PIDINST schema used to create a record.
@@ -65,12 +65,12 @@ their semantics:
   `manufacturerIdentifierType`.
 
 `Model`
-  The name of the model or type of the instrument.  In the
-  case of an off the shelf product, this may be a brand name
-  attributed by the manufacturer.  In the case of a custom built
-  instrument, it may not have a model name.  Hence this property is
-  not mandatory, but recommended if the value can be obtained.  `Model` has
-  optional subproperties `modelIdentifier` and `modelIdentifierType` to be used 
+  The name of the model or type of the instrument.  In the case of an
+  off the shelf product, this may be a brand name attributed by the
+  manufacturer.  In the case of a custom built instrument, it may not
+  have a model name.  Hence this property is not mandatory, but
+  recommended if the value can be obtained.  `Model` has optional
+  subproperties `modelIdentifier` and `modelIdentifierType` to be used
   if an identifier for the model is known.
 
 `Description`
@@ -79,20 +79,21 @@ their semantics:
   what this instrument is and what it can do.
 
 `InstrumentType`
-  A classification of the type of the instrument.  Hierarchical 
+  A classification of the type of the instrument.  Hierarchical
   classification enables grouping of instrument records.
 
-  In the same way as `Owner`, `Manufacturer` and `Model`, `InstrumentType` is 
-  a complex property with subproperties `instrumentTypeName`, 
-  `instrumentTypeIdentifier` and `instrumentTypeIdentifierType`.
+  In the same way as `Owner`, `Manufacturer` and `Model`,
+  `InstrumentType` is a complex property with subproperties
+  `instrumentTypeName`, `instrumentTypeIdentifier` and
+  `instrumentTypeIdentifierType`.
 
 `MeasuredVariable`
   The variables or physical properties that the instrument measures or
-  observes. Some communities have established terminologies 
-  to identify measured variables that are specific to their respective domain 
-  (see :ref:`pidinst-metadata-schema-terminologies`).  If such a 
-  standard is applicable, it should be used for for `MeasuredVariable`.
-  Otherwise, a textual description may be used.
+  observes.  Some communities have established terminologies to
+  identify measured variables that are specific to their respective
+  domain (see :ref:`pidinst-metadata-schema-terminologies`).  If such
+  a standard is applicable, it should be used for for
+  `MeasuredVariable`.  Otherwise, a textual description may be used.
 
 `Date`
   Relevant events pertaining to this instrument instance, such as when

--- a/white-paper/physical-objects.rst
+++ b/white-paper/physical-objects.rst
@@ -42,16 +42,16 @@ the terms *serialNumber* and *inventoryNumber.* There is on-going
 discussion regarding the use of explicit fields for these properties
 in PIDINST.
 
-.. _fig-objects-qr:
 .. figure:: /images/image4.png
+    :name: fig-objects-qr
     :alt: QR code
 
     An example of a webpage QR code that includes an organisation logo
     and re-directs the scanner to the PID URL
     (http://hdl.handle.net/21.T11998/0000-001A-3905-F).
 
-.. _snip-objects-serial:
 .. code-block:: XML
+    :name: snip-objects-serial
     :caption: An instrument serial number expressed in XML
 
       <AlternateIdentifiers>

--- a/white-paper/physical-objects.rst
+++ b/white-paper/physical-objects.rst
@@ -55,7 +55,7 @@ in PIDINST.
     :caption: An instrument serial number expressed in XML
 
       <AlternateIdentifiers>
-         <AlternateIdentifier alternateIdentifierType="serialNumber"">7351-349l-mn24-019f</AlternateIdentifier>
+         <AlternateIdentifier alternateIdentifierType="serialNumber">7351-349l-mn24-019f</AlternateIdentifier>
       </AlternateIdentifiers>
 
 Besides storing e.g. serial numbers in PIDINST schema metadata, it is

--- a/white-paper/registration.rst
+++ b/white-paper/registration.rst
@@ -15,13 +15,13 @@ at PID providers compliant with RDA PIDINST recommendations.
 	   providers.
     :name: tab-register-guidance
 
-    +--------------+--------------------------------+--------------------------------------------------------------------------------------------------+
-    | PID provider | Technical resource             | Metadata schema                                                                                  |
-    +==============+================================+==================================================================================================+
-    | ePIC         | :ref:`epic-cookbook`           | `PIDINST <https://github.com/rdawg-pidinst/schema/blob/master/schema.rst>`_                      |
-    +--------------+--------------------------------+--------------------------------------------------------------------------------------------------+
-    | DataCite     | https://datacite.org/dois.html | `PIDINST to DataCite <https://github.com/rdawg-pidinst/schema/blob/master/schema-datacite.rst>`_ |
-    +--------------+--------------------------------+--------------------------------------------------------------------------------------------------+
+    +--------------+--------------------------+--------------------------------------------------------------------------------------------------+
+    | PID provider | Technical resource       | Metadata schema                                                                                  |
+    +==============+==========================+==================================================================================================+
+    | ePIC         | :ref:`epic-cookbook`     | `PIDINST <https://github.com/rdawg-pidinst/schema/blob/master/schema.rst>`_                      |
+    +--------------+--------------------------+--------------------------------------------------------------------------------------------------+
+    | DataCite     | :ref:`datacite-cookbook` | `PIDINST to DataCite <https://github.com/rdawg-pidinst/schema/blob/master/schema-datacite.rst>`_ |
+    +--------------+--------------------------+--------------------------------------------------------------------------------------------------+
 
 
 Local registration at institutional instrument providers

--- a/white-paper/registration.rst
+++ b/white-paper/registration.rst
@@ -8,12 +8,12 @@ The following resources (:numref:`tab-register-guidance`) provide
 technical guidance for institutions to publish and manage PID records
 at PID providers compliant with RDA PIDINST recommendations.
 
-.. _tab-register-guidance:
 .. table:: Technical guidance for publishing and managing instrument
 	   PIDs at PID providers compliant with RDA PIDINST
 	   recommendations. The table provides links to the relevant
 	   metadata schema that accompanies PID records at PID
 	   providers.
+    :name: tab-register-guidance
 
     +--------------+--------------------------------+--------------------------------------------------------------------------------------------------+
     | PID provider | Technical resource             | Metadata schema                                                                                  |


### PR DESCRIPTION
Various, mostly minor fixes:

- Link the DataCite Cookbook in [Table 6.1](https://docs.pidinst.org/en/latest/white-paper/registration.html#tab-register-guidance), rather than an external resource.
- Fix typo in the code in [Snippet 8.1](https://docs.pidinst.org/en/latest/white-paper/physical-objects.html#snip-objects-serial).
- Fix indentation in JSON examples.
- Fix typographic errors.
- Set a `name` attribute for `table`, `code-block`, and `figure` directives rather than adding an explicit link anchor.
- Set `class longtable` for [Table 5.1](https://docs.pidinst.org/en/latest/white-paper/metadata-schema-recommendations.html#tab-schema-handle-record).
- Set `py_modules` in `setup.py`.

See the [build result](https://docs.pidinst.org/en/misc-fixes/) of the changes.