### PR TITLE
Add a GitHub action to check ReST style

### DIFF
--- a/.github/workflows/rst-lint.yaml
+++ b/.github/workflows/rst-lint.yaml
@@ -1,0 +1,10 @@
+name: Check ReST input files
+on: [push, pull_request]
+jobs:
+  doc8:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+      - name: doc8-check
+        uses: deep-entertainment/doc8-action@v4

--- a/datacite-cookbook/index.rst
+++ b/datacite-cookbook/index.rst
@@ -4,7 +4,7 @@ DataCite Cookbook
 =================
 
 +---------------+------------------------------------------------------+
-| Document type | | Research Data Alliance (RDA)                       | 
+| Document type | | Research Data Alliance (RDA)                       |
 |               | | Persistent Identification of Instruments (PIDINST) |
 |               | | working group output report                        |
 +---------------+------------------------------------------------------+

--- a/epic-cookbook/handles.rst
+++ b/epic-cookbook/handles.rst
@@ -52,20 +52,20 @@ ePIC member may use their own API end-point.
 To generate a PID handle record automatically generating a UUID for
 the suffix::
 
-	curl -v -u "username:password" -H "Accept:application/json" -H "Content-Type:application/json" -X POST --data '[{"type":"URL","parsed_data":"https://linkedsystems.uk/system/instance/TOOL0022_2490/current/"}]' http://vm04.pid.gwdg.de:8081/handles/21.T11998/
+        curl -v -u "username:password" -H "Accept:application/json" -H "Content-Type:application/json" -X POST --data '[{"type":"URL","parsed_data":"https://linkedsystems.uk/system/instance/TOOL0022_2490/current/"}]' http://vm04.pid.gwdg.de:8081/handles/21.T11998/
 
 ``Result:`` https://vm04.pid.gwdg.de:8081/handles/21.T11998/0000-001A-64A4-A
 
 To generate a PID handle record automatically generating a UUID within
 the suffix::
 
-	curl -v -u "username:password" -H "Accept:application/json" -H "Content-Type:application/json" -X POST --data '[{"type":"URL","parsed_data":"https://linkedsystems.uk/system/instance/TOOL0022_2490/current/"}]' http://vm04.pid.gwdg.de:8081/handles/21.T11998/\?prefix=BODC\&suffix=TEST
+        curl -v -u "username:password" -H "Accept:application/json" -H "Content-Type:application/json" -X POST --data '[{"type":"URL","parsed_data":"https://linkedsystems.uk/system/instance/TOOL0022_2490/current/"}]' http://vm04.pid.gwdg.de:8081/handles/21.T11998/\?prefix=BODC\&suffix=TEST
 
 ``Result:`` https://vm04.pid.gwdg.de:8081/handles/21.T11998/BODC-0000-001A-64A3-B-TEST
 
 To manually generate a suffix using PUT method::
 
-	curl -v -u "username:password" -H "Accept:application/json" -H "Content-Type:application/json" -X PUT --data '[{"type":"URL","parsed_data":"https://linkedsystems.uk/system/instance/TOOL0022_2490/current/"}]' http://vm04.pid.gwdg.de:8081/handles/21.T11998/564987-8865544-9998
+        curl -v -u "username:password" -H "Accept:application/json" -H "Content-Type:application/json" -X PUT --data '[{"type":"URL","parsed_data":"https://linkedsystems.uk/system/instance/TOOL0022_2490/current/"}]' http://vm04.pid.gwdg.de:8081/handles/21.T11998/564987-8865544-9998
 
 ``Result:`` https://vm04.pid.gwdg.de:8081/handles/21.T11998/564987-8865544-9998
 
@@ -96,13 +96,14 @@ JSON file (see :download:`JSON example </examples/ePIC_json_example.json>`).
 
 Directly specifying properties within the cURL request::
 
-	curl -v -u "username:password" -H "Accept:application/json" -H "Content-Type:application/json" -X PUT --data '[{"type": "21.T11148/8eb858ee0b12e8e463a5","parsed_data": "{\"identifierValue\":\"http://hdl.handle.net/21.T11998/BODC-0000-001A-64A3-B-TEST\",\"identiferType\":\"MeasuringInstrument\"}"},{"type": "21.T11148/4eaec4bc0f1df68ab2a7","parsed_data": "[{\"Owner\": {\"ownerName\":\"National Oceanography Centre\",\"ownerContact\":\"louise.darroch@bodc.ac.uk\",\"ownerIdentifier\":{\"ownerIdentifierValue\":\"http://vocab.nerc.ac.uk/collection/B75/current/ORG00009/\",\"ownerIdentifierType\":\"URL\"}}}]"}]' http://vm04.pid.gwdg.de:8081/handles/21.T11998/BODC-0000-001A-64A3-B-TEST
+        curl -v -u "username:password" -H "Accept:application/json" -H "Content-Type:application/json" -X PUT --data '[{"type": "21.T11148/8eb858ee0b12e8e463a5","parsed_data": "{\"identifierValue\":\"http://hdl.handle.net/21.T11998/BODC-0000-001A-64A3-B-TEST\",\"identiferType\":\"MeasuringInstrument\"}"},{"type": "21.T11148/4eaec4bc0f1df68ab2a7","parsed_data": "[{\"Owner\": {\"ownerName\":\"National Oceanography Centre\",\"ownerContact\":\"louise.darroch@bodc.ac.uk\",\"ownerIdentifier\":{\"ownerIdentifierValue\":\"http://vocab.nerc.ac.uk/collection/B75/current/ORG00009/\",\"ownerIdentifierType\":\"URL\"}}}]"}]' http://vm04.pid.gwdg.de:8081/handles/21.T11998/BODC-0000-001A-64A3-B-TEST
 
-*Note: Double quotes must be escaped with a backslash (\\) within the JSON parsed_data string*
+*Note: Double quotes must be escaped with a backslash (\\) within the
+JSON parsed_data string*
 
 Specifying properties with a JSON file::
 
-	curl -v -u "username:password" -H "Accept:application/json" -H "Content-Type:application/json" -X PUT --data @/users/.../ePIC_json_example.json http://vm04.pid.gwdg.de:8081/handles/21.T11998/BODC-0000-001A-64A3-B-TEST
+        curl -v -u "username:password" -H "Accept:application/json" -H "Content-Type:application/json" -X PUT --data @/users/.../ePIC_json_example.json http://vm04.pid.gwdg.de:8081/handles/21.T11998/BODC-0000-001A-64A3-B-TEST
 
 
 Managing PIDs
@@ -119,19 +120,19 @@ Server: ``vm04.pid.gwdg.de``, Port: ``8081``, Resources: ``handles/``
 
 ::
 
-	curl -D- -u "username:password" -X GET -H "Content-Type: application/json" http://vm04.pid.gwdg.de:8081/handles/21.T11998/BODC-0000-001A-64A3-B-TEST
+        curl -D- -u "username:password" -X GET -H "Content-Type: application/json" http://vm04.pid.gwdg.de:8081/handles/21.T11998/BODC-0000-001A-64A3-B-TEST
 
 **Delete a PID (not allowed for production Handles):**
 
 ::
 
-	curl -v -u "username:password" -H "Accept:application/json" -H "Content-Type:application/json" -X DELETE http://vm04.pid.gwdg.de:8081/handles/21.T11998/BODC-0000-001A-64A3-B-TEST
+        curl -v -u "username:password" -H "Accept:application/json" -H "Content-Type:application/json" -X DELETE http://vm04.pid.gwdg.de:8081/handles/21.T11998/BODC-0000-001A-64A3-B-TEST
 
 **Update a PID:**
 
 ::
 
-	curl -v -u "username:password" -H "Accept:application/json" -H "Content-Type:application/json" -X PUT --data '[{"type":"21.T11148/8eb858ee0b12e8e463a5","parsed_data":"{\"identifierValue\":\"http://hdl.handle.net/21.T11998/BODC-0000-001A-64A3-B-TEST\",\"identiferType\":\"MeasuringInstrument\"}"}]' http://vm04.pid.gwdg.de:8081/handles/21.T11998/BODC-0000-001A-64A3-B-TEST
+        curl -v -u "username:password" -H "Accept:application/json" -H "Content-Type:application/json" -X PUT --data '[{"type":"21.T11148/8eb858ee0b12e8e463a5","parsed_data":"{\"identifierValue\":\"http://hdl.handle.net/21.T11998/BODC-0000-001A-64A3-B-TEST\",\"identiferType\":\"MeasuringInstrument\"}"}]' http://vm04.pid.gwdg.de:8081/handles/21.T11998/BODC-0000-001A-64A3-B-TEST
 
 
 Using the Handle API
@@ -161,36 +162,36 @@ convention ${INDEX}_${PREFIX}_${USER}_???.pem.
 
 ::
 
-	PATH="/SomePath2Certs"
-	PREFIX="21.T11998" # prefix of the PID service
-	USER="USER21" # USER that has access to PIDs under $PREFIX
-	INDEX="300"  # index where HS_PUBKEY is stored for $USER
-	SERVPORT="vm04.pid.gwdg.de:8001" # PID service and port
-	VERBOSE="" # optional “ -v "
-	# Certificates
-	USERKEY="${PATH}/Certificates/${INDEX}_${PREFIX}_${USER}_privkey.pem"
-	USERCERT="${PATH}/Certificates/${INDEX}_${PREFIX}_${USER}_certificate_only.pem"
+        PATH="/SomePath2Certs"
+        PREFIX="21.T11998" # prefix of the PID service
+        USER="USER21" # USER that has access to PIDs under $PREFIX
+        INDEX="300"  # index where HS_PUBKEY is stored for $USER
+        SERVPORT="vm04.pid.gwdg.de:8001" # PID service and port
+        VERBOSE="" # optional “ -v "
+        # Certificates
+        USERKEY="${PATH}/Certificates/${INDEX}_${PREFIX}_${USER}_privkey.pem"
+        USERCERT="${PATH}/Certificates/${INDEX}_${PREFIX}_${USER}_certificate_only.pem"
 
 **Create Handle:**
 
 ::
 
-	curl -s --insecure ${VERBOSE} --key ${USERKEY} --cert ${USERCERT} -H "Content-Type:application/json" -H 'Authorization: Handle clientCert="true"' -X PUT --data  '{"values":[{"index":100,"type":"HS_ADMIN","data":{"value":{"index":'${INDEX}',"handle":"'${PREFIX}'\/'${USER}'","permissions":"011111110011","format":"admin"},"format":"admin"}},{"index":1,"type":"URL","data":"www.gwdg.de"}]}' https://${SERVPORT}/api/handles/${PREFIX}/test_epic3_1234
+        curl -s --insecure ${VERBOSE} --key ${USERKEY} --cert ${USERCERT} -H "Content-Type:application/json" -H 'Authorization: Handle clientCert="true"' -X PUT --data  '{"values":[{"index":100,"type":"HS_ADMIN","data":{"value":{"index":'${INDEX}',"handle":"'${PREFIX}'\/'${USER}'","permissions":"011111110011","format":"admin"},"format":"admin"}},{"index":1,"type":"URL","data":"www.gwdg.de"}]}' https://${SERVPORT}/api/handles/${PREFIX}/test_epic3_1234
 
 **Get Handle created:**
 
 ::
 
-	curl -s --insecure ${VERBOSE} --key ${USERKEY} --cert ${USERCERT} -H "Content-Type:application/json" -H 'Authorization: Handle clientCert="true"' -q https://${SERVPORT}/api/handles/test_epic3_1234
-	
+        curl -s --insecure ${VERBOSE} --key ${USERKEY} --cert ${USERCERT} -H "Content-Type:application/json" -H 'Authorization: Handle clientCert="true"' -q https://${SERVPORT}/api/handles/test_epic3_1234
+
 **Modify Handle created:**
 
 ::
 
-	curl -s --insecure ${VERBOSE} --key ${USERKEY} --cert ${USERCERT} -H "Content-Type:application/json" -H 'Authorization: Handle clientCert="true"' -X PUT --data  '{"values":[{"index":100,"type":"HS_ADMIN","data":{"value":{"index":'${INDEX}',"handle":"'${PREFIX}'\/'${USER}'","permissions":"011111110011","format":"admin"},"format":"admin"}},{"index":1,"type":"URL","data":"pid.gwdg.de"}]}' https://${SERVPORT}/api/handles/${PREFIX}/test_epic3_1234
+        curl -s --insecure ${VERBOSE} --key ${USERKEY} --cert ${USERCERT} -H "Content-Type:application/json" -H 'Authorization: Handle clientCert="true"' -X PUT --data  '{"values":[{"index":100,"type":"HS_ADMIN","data":{"value":{"index":'${INDEX}',"handle":"'${PREFIX}'\/'${USER}'","permissions":"011111110011","format":"admin"},"format":"admin"}},{"index":1,"type":"URL","data":"pid.gwdg.de"}]}' https://${SERVPORT}/api/handles/${PREFIX}/test_epic3_1234
 
 **Delete Handle created:**
 
 ::
 
-	curl -s --insecure ${VERBOSE} --key ${USERKEY} --cert ${USERCERT} -H "Content-Type:application/json" -H 'Authorization: Handle clientCert="true"' -X DELETE  https://${SERVPORT}/api/handles/test_epic3_1234
+        curl -s --insecure ${VERBOSE} --key ${USERKEY} --cert ${USERCERT} -H "Content-Type:application/json" -H 'Authorization: Handle clientCert="true"' -X DELETE  https://${SERVPORT}/api/handles/test_epic3_1234

--- a/epic-cookbook/index.rst
+++ b/epic-cookbook/index.rst
@@ -4,7 +4,7 @@ ePIC Cookbook
 =============
 
 +---------------+------------------------------------------------------+
-| Document type | | Research Data Alliance (RDA)                       | 
+| Document type | | Research Data Alliance (RDA)                       |
 |               | | Persistent Identification of Instruments (PIDINST) |
 |               | | working group output report                        |
 +---------------+------------------------------------------------------+

--- a/white-paper/authors.rst
+++ b/white-paper/authors.rst
@@ -3,7 +3,8 @@ British Oceanographic Data Centre, National Oceanography Centre,
 Liverpool, L3 5DA, United Kingdom
 
 *Robert Huber* (rhuber@uni-bremen.de, https://orcid.org/0000-0003-3000-0020),
-MARUM - Center for Marine Environmental Sciences, University of Bremen, Leobener Str. 8, 28359 Bremen, Germany
+MARUM - Center for Marine Environmental Sciences, University of Bremen,
+Leobener Str. 8, 28359 Bremen, Germany
 
 *Anusuriya Devaraju* (anusuriya.devaraju@csiro.au, https://orcid.org/0000-0003-0870-3192),
 CSIRO Mineral Resources, 26 Dick Perry Avenue, Kensington WA 6151, Australia
@@ -62,7 +63,8 @@ Polar and Marine Research. Am Handelshafen 12, 27570, Bremerhaven,
 Germany
 
 *Tina Dohna* (tdohna@marum.de, https://orcid.org/0000-0002-5948-0980),
-MARUM - Center for Marine Environmental Sciences, University of Bremen, Leobener Str. 8, 28199 Bremen, Germany
+MARUM - Center for Marine Environmental Sciences, University of Bremen,
+Leobener Str. 8, 28199 Bremen, Germany
 
 *Jens Klump* (jens.klump@csiro.au, https://orcid.org/0000-0001-5911-6022),
 CSIRO Mineral Resources, 26 Dick Perry Avenue, Kensington WA 6151, Australia

--- a/white-paper/create-new-pid.rst
+++ b/white-paper/create-new-pid.rst
@@ -27,7 +27,7 @@ for the superceded PID as shown in
 .. code-block:: XML
     :name: snip-create-superseding-xml
     :caption: The use of the relatedIdentifier property to represent
-	      superseding PID records in XML
+              superseding PID records in XML
 
       <relatedIdentifiers>
          <relatedIdentifier relatedIdentifierType="DOI" relationType="IsNewVersionOf">10.4232/10.CPoS-2013-02en</relatedIdentifier>
@@ -36,7 +36,7 @@ for the superceded PID as shown in
 .. code-block:: XML
     :name: snip-create-superseded-xml
     :caption: The use of the relatedIdentifier property to represent
-	      superseded PID records in XML
+              superseded PID records in XML
 
       <relatedIdentifiers>
          <relatedIdentifier relatedIdentifierType="DOI" relationType="IsPreviousVersionOf">http://hdl.handle.net/21.T11998/0000-001A-3905-F</relatedIdentifier>
@@ -45,7 +45,7 @@ for the superceded PID as shown in
 .. code-block:: JSON
     :name: snip-create-superseding-json
     :caption: The use of the relatedIdentifier property to represent
-	      superseding PID records in JSON
+              superseding PID records in JSON
 
       [{
         "RelatedIdentifier":{
@@ -58,7 +58,7 @@ for the superceded PID as shown in
 .. code-block:: JSON
     :name: snip-create-superseded-json
     :caption: The use of the relatedIdentifier property to represent
-	      superseded PID records in JSON
+              superseded PID records in JSON
 
       [{
         "RelatedIdentifier":{

--- a/white-paper/landing-page-content.rst
+++ b/white-paper/landing-page-content.rst
@@ -21,8 +21,8 @@ instruments; to enable users to put data into context; and to automate
 instrument metadata into data workflows.
 
 .. table:: Descriptive landing page metadata describing measuring
-	   instruments. To be used in conjunction with the core
-	   instrument metadata used in the PIDINST schema.
+           instruments. To be used in conjunction with the core
+           instrument metadata used in the PIDINST schema.
     :name: tab-landing-content-inst
 
     +-------------------+-------------------------------------------------+
@@ -51,11 +51,11 @@ instrument metadata into data workflows.
     +-------------------+-------------------------------------------------+
 
 .. table:: Descriptive, landing page metadata that describes the
-	   history of events, operations or changes during the
-	   lifetime of an instrument. This kind of metadata should be
-	   associated to dates and ideally accompanied by comments. To
-	   be used in conjunction with the core instrument metadata
-	   used in the PIDINST schema.
+           history of events, operations or changes during the
+           lifetime of an instrument. This kind of metadata should be
+           associated to dates and ideally accompanied by comments. To
+           be used in conjunction with the core instrument metadata
+           used in the PIDINST schema.
     :name: tab-landing-content-events
 
     +--------------------+------------------------------------------------+

--- a/white-paper/landing-page-encoding.rst
+++ b/white-paper/landing-page-encoding.rst
@@ -46,7 +46,7 @@ respective representation in JSON-LD of the schema example shown in
 .. code-block:: JSON
     :name: snip-landing-encoding-json-ld
     :caption: representation in JSON-LD of the example of
-	      :numref:`tab-schema-handle-record`.
+              :numref:`tab-schema-handle-record`.
 
       {
         "@context" : {
@@ -129,8 +129,8 @@ respective representation in JSON-LD of the schema example shown in
           {
             "Manufacturer" : {
               "manufacturerIdentifier" : {
-		"manufacturerIdentifierType" : "URL",
-		"manufacturerIdentifierValue" : "http://vocab.nerc.ac.uk/collection/L35/current/MAN0013/"
+                "manufacturerIdentifierType" : "URL",
+                "manufacturerIdentifierValue" : "http://vocab.nerc.ac.uk/collection/L35/current/MAN0013/"
               },
               "manufacturerName" : "Sea-Bird Scientific",
               "modelName" : "SBE 37-IM"
@@ -165,8 +165,8 @@ respective representation in JSON-LD of the schema example shown in
             "Owner" : {
               "ownerContact" : "louise.darroch@bodc.ac.uk",
               "ownerIdentifier" : {
-		"ownerIdentifierType" : "URL",
-		"ownerIdentifierValue" : "http://vocab.nerc.ac.uk/collection/B75/current/ORG00009/"
+                "ownerIdentifierType" : "URL",
+                "ownerIdentifierValue" : "http://vocab.nerc.ac.uk/collection/B75/current/ORG00009/"
               },
               "ownerName" : "National Oceanography Centre"
             }
@@ -202,9 +202,9 @@ PID suffixes:
 .. code-block:: turtle
     :name: snip-landing-encoding-turtle
     :caption: representation in Turtle Terse RDF of the NERC example
-	      of :numref:`tab-schema-handle-record` that was generated
-	      by a JSON-LD to RDF converter from the JSON-LD in
-	      :numref:`snip-landing-encoding-json-ld`.
+              of :numref:`tab-schema-handle-record` that was generated
+              by a JSON-LD to RDF converter from the JSON-LD in
+              :numref:`snip-landing-encoding-json-ld`.
 
       @prefix ns0: <http://hdl.handle.net/21.T11148/> .
       @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
@@ -281,11 +281,11 @@ server.
 .. code-block:: xml
     :name: snip-landing-encoding-sensorml
     :caption: An example of expressing an instrument PID
-	      (http://hdl.handle.net/21.T11998/0000-001A-3905-F) as
-	      identifying metadata within a SensorML technical
-	      description using the *sml:identifier* property for a
-	      SeaBird Scientific SBE 37 Conductivity, temperature and
-	      depth sensor.
+              (http://hdl.handle.net/21.T11998/0000-001A-3905-F) as
+              identifying metadata within a SensorML technical
+              description using the *sml:identifier* property for a
+              SeaBird Scientific SBE 37 Conductivity, temperature and
+              depth sensor.
 
       <sml:identifier>
         <sml:Term definition="http://www.example.com/definitions/pidinst/">

--- a/white-paper/linking-datasets.rst
+++ b/white-paper/linking-datasets.rst
@@ -225,12 +225,14 @@ should be used if linking more than one instrument.
 OpenAIRE CERIF metadata
 -----------------------
 
-The *OpenAIRE Guidelines for CRIS Managers* [#crisguidelines2023]_ provide orientation for Research Information System (CRIS) managers
-to expose their metadata in a way that is compatible with the OpenAIRE
-infrastructure as well as the European Open Science Cloud (EOSC). These
-Guidelines also serve as an example of a CERIF-based (Common European Research Information Format)
-standard for information interchange between individual CRISs and other
-research e-Infrastructures.
+The *OpenAIRE Guidelines for CRIS Managers* [#crisguidelines2023]_
+provide orientation for Research Information System (CRIS) managers to
+expose their metadata in a way that is compatible with the OpenAIRE
+infrastructure as well as the European Open Science Cloud (EOSC).
+These Guidelines also serve as an example of a CERIF-based (Common
+European Research Information Format) standard for information
+interchange between individual CRISs and other research
+e-Infrastructures.
 
 The metadata format described by the Guidelines are includes Equipment
 which could contain Instruments as well via the `GeneratedBy property`_.

--- a/white-paper/metadata-schema-recommendations.rst
+++ b/white-paper/metadata-schema-recommendations.rst
@@ -38,14 +38,14 @@ An example of the use of common terminologies in ePIC records is shown
 in :numref:`tab-schema-handle-record`.
 
 .. table:: Handle record of instrument identifier
-	   http://hdl.handle.net/21.T11998/0000-001A-3905-F displaying
-	   the use of common terminologies to identify instrument
-	   metadata compliant with the PIDINST schema as implemented
-	   by ePIC.  The terminologies used are published on the `NERC
-	   Vocabulary Server (NVS) <NVS_>`_.  The data for each
-	   metadata property is provided in JSON.  The Handle record
-	   can be viewed at
-	   http://hdl.handle.net/21.T11998/0000-001A-3905-F?noredirect
+           http://hdl.handle.net/21.T11998/0000-001A-3905-F displaying
+           the use of common terminologies to identify instrument
+           metadata compliant with the PIDINST schema as implemented
+           by ePIC.  The terminologies used are published on the `NERC
+           Vocabulary Server (NVS) <NVS_>`_.  The data for each
+           metadata property is provided in JSON.  The Handle record
+           can be viewed at
+           http://hdl.handle.net/21.T11998/0000-001A-3905-F?noredirect
     :name: tab-schema-handle-record
     :class: longtable
 
@@ -136,7 +136,7 @@ in :numref:`tab-schema-handle-record`.
     |                                    |           "http://vocab.nerc.ac.uk/collection/L05/current/350/",                                             |
     |                                    |         "instrumentTypeIdentifierType":"URL"                                                                 |
     |                                    |       }                                                                                                      |
-    |                                    |     }]                                                                                                       |                    
+    |                                    |     }]                                                                                                       |
     +------------------------------------+--------------------------------------------------------------------------------------------------------------+
     | | 21.T11148/72928b84e060d491ee41   | .. code-block:: JSON                                                                                         |
     | | (MeasuredVariables)              |                                                                                                              |

--- a/white-paper/metadata-schema.rst
+++ b/white-paper/metadata-schema.rst
@@ -146,8 +146,8 @@ their semantics:
    https://github.com/rdawg-pidinst/schema/blob/master/schema-datacite.rst
 
 .. [#pidinst2022v1_0]
-   Krahl, R., Darroch, L., Huber, R., Devaraju, A., Klump, J., Habermann, T., 
-   Stocker, M., & The Research Data Alliance Persistent Identification of 
-   Instruments Working Group members (2022). Metadata Schema for the 
-   Persistent Identification of Instruments (1.0). Research Data Alliance. 
+   Krahl, R., Darroch, L., Huber, R., Devaraju, A., Klump, J., Habermann, T.,
+   Stocker, M., & The Research Data Alliance Persistent Identification of
+   Instruments Working Group members (2022). Metadata Schema for the
+   Persistent Identification of Instruments (1.0). Research Data Alliance.
    DOI: https://doi.org/10.15497/RDA00070

--- a/white-paper/registration.rst
+++ b/white-paper/registration.rst
@@ -9,10 +9,10 @@ technical guidance for institutions to publish and manage PID records
 at PID providers compliant with RDA PIDINST recommendations.
 
 .. table:: Technical guidance for publishing and managing instrument
-	   PIDs at PID providers compliant with RDA PIDINST
-	   recommendations. The table provides links to the relevant
-	   metadata schema that accompanies PID records at PID
-	   providers.
+           PIDs at PID providers compliant with RDA PIDINST
+           recommendations. The table provides links to the relevant
+           metadata schema that accompanies PID records at PID
+           providers.
     :name: tab-register-guidance
 
     +--------------+--------------------------+--------------------------------------------------------------------------------------------------+


### PR DESCRIPTION
After a day of reviewing pull requests and resolving merge conflicts, I considered it might be a good idea to do something to enforce good reStructuredText style.  So I add a GitHub action to automatically run a ReST linter ([doc8](https://github.com/pycqa/doc8)) to check our source files.  As a result, I fixed various ReST style issues.