### PR TITLE
Review Read the Docs build

### DIFF
--- a/.github/workflows/rst-lint.yaml
+++ b/.github/workflows/rst-lint.yaml
@@ -1,5 +1,10 @@
 name: Check ReST input files
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - develop
+      - master
+  pull_request:
 jobs:
   doc8:
     runs-on: ubuntu-latest

--- a/.requirements
+++ b/.requirements
@@ -1,4 +1,3 @@
-jinja2<3.1
+setuptools
 setuptools_scm
-sphinx>=2,<3
-sphinx-rtd-theme>=0.5,<1
+sphinx-rtd-theme

--- a/.requirements
+++ b/.requirements
@@ -1,3 +1,3 @@
+git-props
 setuptools
-setuptools_scm
 sphinx-rtd-theme

--- a/conf.py
+++ b/conf.py
@@ -19,11 +19,11 @@ copyright = "2020, %s" % author
 
 # The full version, including alpha/beta/rc tags
 # Dummy for the time being
-release = _meta.__version__
+release = _meta.version
 # The short X.Y version
 version = ".".join(release.split(".")[0:2])
 
-today = _meta.__date__
+today = _meta.date
 
 # -- General configuration ---------------------------------------------------
 

--- a/conf.py
+++ b/conf.py
@@ -15,7 +15,7 @@ import _meta
 
 project = "PIDINST"
 author = "RDA Persistent Identification of Instruments WG"
-copyright = "2020, %s" % author
+copyright = "2020–2024, %s" % author
 
 # The full version, including alpha/beta/rc tags
 # Dummy for the time being
@@ -62,7 +62,7 @@ numfig_format = {
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/conf.py
+++ b/conf.py
@@ -6,9 +6,13 @@
 # full list see the documentation:
 # http://www.sphinx-doc.org/en/master/config
 
-import os
+from pathlib import Path
 import sys
-sys.path.insert(0, os.path.abspath('.'))
+
+maindir = Path(__file__).resolve().parent
+sys.path[0] = str(maindir)
+sys.dont_write_bytecode = True
+
 import _meta
 
 # -- Project information -----------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,8 @@ class meta(setuptools.Command):
     description = "generate meta files"
     user_options = []
     meta_template = '''
-__version__ = "%(version)s"
-__date__ = "%(date)s"
+version = "%(version)s"
+date = "%(date)s"
 '''
 
     def initialize_options(self):

--- a/setup.py
+++ b/setup.py
@@ -9,34 +9,9 @@ import datetime
 import os
 from pathlib import Path
 import subprocess
+import gitprops
 
-
-class GitProps:
-    """Determine properties of the git repository.
-    """
-
-    def __init__(self, root="."):
-        self.root = Path(root).resolve()
-
-    def _exec(self, cmd):
-        proc = subprocess.run(cmd.split(),
-                              stdout=subprocess.PIPE,
-                              stderr=subprocess.PIPE,
-                              cwd=self.root,
-                              check=True,
-                              env=dict(os.environ, LC_ALL='C'),
-                              universal_newlines=True)
-        return proc.stdout.strip()
-
-    def is_dirty(self):
-        return bool(self._exec("git status --porcelain --untracked-files=no"))
-
-    def get_date(self):
-        if self.is_dirty():
-            return datetime.date.today()
-        else:
-            ts = int(self._exec("git log -1 --format=%cd --date=unix"))
-            return datetime.date.fromtimestamp(ts)
+version = str(gitprops.get_version())
 
 
 class meta(setuptools.Command):
@@ -55,12 +30,11 @@ __date__ = "%(date)s"
         pass
 
     def run(self):
-        git = GitProps()
         version = self.distribution.get_version()
         log.info("version: %s", version)
         values = {
             'version': version,
-            'date': git.get_date().strftime("%e %B %Y").strip(),
+            'date': gitprops.get_date().strftime("%e %B %Y").strip(),
         }
         with Path("_meta.py").open("wt") as f:
             print(self.meta_template % values, file=f)
@@ -73,10 +47,10 @@ class install(setuptools.command.install.install):
 
 
 setup(
-    use_scm_version=True,
+    version = version,
     url = "https://github.com/rdawg-pidinst/white-paper",
     python_requires = '>= 3.6',
-    install_requires = ['setuptools_scm'],
+    install_requires = ["setuptools", "git-props"],
     py_modules = [],
     cmdclass = {'meta': meta, 'install': install},
 )


### PR DESCRIPTION
Review documentation build process at Read the Docs:

- Review requirements, essentially updating the Sphinx version used in the build. This fixes a build failure due to version incompatibilities.
- Use [git-props](https://github.com/RKrahl/git-props), obsoleting `setuptools_scm` and `class GitProps` in `setup.py`.
- Various minor tweaks in the tool chain.
