### PR TITLE
Update authors: add R. Hanisch and J. Lau

### DIFF
--- a/white-paper/authors.rst
+++ b/white-paper/authors.rst
@@ -77,11 +77,11 @@ Hannover, Welfengarten 1, 30167 Hannover, Germany
 *Andreas Czerniak* (andreas.czerniak@uni-bielefeld.de, https://orcid.org/0000-0003-3883-4169),
 Bielefeld University Library, Universitätsstr. 25, 33615 Bielefeld, Germany
 
-*Robert J. Hanisch* (https://orcid.org/0000-0002-6853-4602)
+*Robert J. Hanisch* (robert.hanisch@nist.gov, https://orcid.org/0000-0002-6853-4602)
 Office of Data and Informatics, Material Measurement Laboratory,
 National Institute of Standards and Technology, Gaithersburg, MD, USA
 
-*June W. Lau* (https://orcid.org/0000-0002-5233-4956)
+*June W. Lau* (june.lau@nist.gov, https://orcid.org/0000-0002-5233-4956)
 Office of Data and Informatics, Material Measurement Laboratory,
 National Institute of Standards and Technology, Gaithersburg, MD, USA
 

--- a/white-paper/authors.rst
+++ b/white-paper/authors.rst
@@ -77,5 +77,13 @@ Hannover, Welfengarten 1, 30167 Hannover, Germany
 *Andreas Czerniak* (andreas.czerniak@uni-bielefeld.de, https://orcid.org/0000-0003-3883-4169),
 Bielefeld University Library, Universitätsstr. 25, 33615 Bielefeld, Germany
 
+*Robert J. Hanisch* (https://orcid.org/0000-0002-6853-4602)
+Office of Data and Informatics, Material Measurement Laboratory,
+National Institute of Standards and Technology, Gaithersburg, MD, USA
+
+*June W. Lau* (https://orcid.org/0000-0002-5233-4956)
+Office of Data and Informatics, Material Measurement Laboratory,
+National Institute of Standards and Technology, Gaithersburg, MD, USA
+
 *The Research Data Alliance Persistent Identification of Instruments
 Working Group members* (https://www.rd-alliance.org/node/57186/members)


### PR DESCRIPTION
I neglected in #32 to update the authors list, so I catch up here:

Add Robert Hanisch and June Lau to authors: they provided the NIST adoption story.