### PR TITLE
Change the presentation of the index page to make Cookbooks appear as parts of the White Paper

### DIFF
--- a/datacite-cookbook/index.rst
+++ b/datacite-cookbook/index.rst
@@ -3,12 +3,6 @@
 DataCite Cookbook
 =================
 
-+---------------+------------------------------------------------------+
-| Document type | | Research Data Alliance (RDA)                       |
-|               | | Persistent Identification of Instruments (PIDINST) |
-|               | | working group output report                        |
-+---------------+------------------------------------------------------+
-
 .. toctree::
    :numbered:
 

--- a/epic-cookbook/index.rst
+++ b/epic-cookbook/index.rst
@@ -3,12 +3,6 @@
 ePIC Cookbook
 =============
 
-+---------------+------------------------------------------------------+
-| Document type | | Research Data Alliance (RDA)                       |
-|               | | Persistent Identification of Instruments (PIDINST) |
-|               | | working group output report                        |
-+---------------+------------------------------------------------------+
-
 .. toctree::
    :numbered:
 

--- a/index.rst
+++ b/index.rst
@@ -46,17 +46,18 @@ The group produced the following outputs:
   This RDA recommendation defines the Metadata Schema.
 
 * :ref:`white-paper` :raw-html:`<br />`
-  This white paper provides recommendations for the use of instrument
+  This White Paper provides recommendations for the use of instrument
   PIDs and gives technical details that go beyond the overview
   provided in the Data Science Journal paper.  It is expected to
   evolve with new user requirements and working group activities.
+  This documentation includes:
 
-* :ref:`epic-cookbook` :raw-html:`<br />`
-  Detailed instructions on how to create instrument PIDs using the
-  ePIC infrastructure.
+  * :ref:`epic-cookbook` :raw-html:`<br />`
+    Detailed instructions on how to create instrument PIDs using the
+    ePIC infrastructure.
 
-* :ref:`datacite-cookbook` :raw-html:`<br />`
-  Detailed instructions on how to create DataCite DOIs for instruments.
+  * :ref:`datacite-cookbook` :raw-html:`<br />`
+    Detailed instructions on how to create DataCite DOIs for instruments.
 
 .. image:: /images/cc-by.*
     :alt: Creative Commons License


### PR DESCRIPTION
Close #48.

I also suggest to remove those funny 

| Document type | RDA ... working group output report |
|---------------|-------------------------------------|

blocks from the index pages of the Cookbooks respectively. It simply does not make sense to have them in the individual parts if we consider the whole thing one dosument.