### PR TITLE
Update Read the Docs build configuration

### DIFF
--- a/.github/workflows/rst-lint.yaml
+++ b/.github/workflows/rst-lint.yaml
@@ -12,4 +12,4 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v4
       - name: doc8-check
-        uses: deep-entertainment/doc8-action@v4
+        uses: deep-entertainment/doc8-action@v5

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+PYTHON        = python3
 SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
 SPHINXPROJ    = PIDINST
@@ -18,7 +19,7 @@ $(BUILDERS): $(STATIC_SOURCEDIRS) _meta.py
 	$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 _meta.py:
-	python3 setup.py meta
+	$(PYTHON) setup.py meta
 
 clean:
 	rm -rf __pycache__

--- a/conf.py
+++ b/conf.py
@@ -6,6 +6,7 @@
 # full list see the documentation:
 # http://www.sphinx-doc.org/en/master/config
 
+import os
 from pathlib import Path
 import sys
 
@@ -89,6 +90,15 @@ html_theme = 'sphinx_rtd_theme'
 # documentation.
 #
 # html_theme_options = {}
+
+# Define the canonical URL if you are using a custom domain on Read the Docs
+html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
+
+# Tell Jinja2 templates the build is running on Read the Docs
+if os.environ.get("READTHEDOCS", "") == "True":
+    if "html_context" not in globals():
+        html_context = {}
+    html_context["READTHEDOCS"] = True
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,7 @@ import setuptools
 from setuptools import setup
 import setuptools.command.install
 from distutils import log
-import datetime
-import os
 from pathlib import Path
-import subprocess
 import gitprops
 
 version = str(gitprops.get_version())


### PR DESCRIPTION
Addons are now enabled in the Read the Docs build.  This PR adds a few minor configuration changes that are required to make sure that the build at RtD continues to work as usual.  Close #54.

While we are at it, take the opportunity to review a few very minor things in the build tool chain (`Makefile`, `setup.py`, GitHub actions).